### PR TITLE
fix: includes for non-module resources don't work

### DIFF
--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessor.java
@@ -31,7 +31,19 @@ public class SlingResourceIncludeProcessor extends IncludeProcessor {
         String content = "Invalid include: " + target;
 
         if(includeResource != null) {
-            content = includeResource.getChild("asciidoc").getChild("jcr:content").getValueMap().get("jcr:data", String.class);
+            // Included resource might be a plain file or another module
+            if( includeResource.getChild("asciidoc") != null ) {
+                content = includeResource.getChild("asciidoc")
+                    .getChild("jcr:content")
+                    .getValueMap()
+                    .get("jcr:data", String.class);
+            } else {
+                // It's a plain file
+                content = includeResource
+                    .getChild("jcr:content")
+                    .getValueMap()
+                    .get("jcr:data", String.class);
+            }
         }
 
         reader.push_include(content, target, target, 1, attributes);


### PR DESCRIPTION
asciidoc includes don't work when including regular files (non-modules)