### PR TITLE
enable sling models and create a Module model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
                             SLING-INF/users;overwrite:=false;uninstall:=false,
                             SLING-INF/oak:index;overwrite:=true;uninstall:=true;path:=/oak:index
                         ]]></Sling-Initial-Content>
+                        <Sling-Model-Packages>
+                            com.redhat.pantheon.model
+                        </Sling-Model-Packages>
                         <Import-Package>
                             !jnr.a64asm,!jnr.x86asm,!org.apache.bsf,!org.apache.bsf.util,
                             !org.apache.tools.ant,!org.joda.convert,!org.objectweb.asm,!sun.misc,*
@@ -66,6 +69,13 @@
                         <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
                     </instructions>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.bnd.models</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.sling</groupId>
@@ -238,6 +248,18 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.api</artifactId>
             <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.models.api</artifactId>
+            <version>1.3.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+            <version>1.1</version>
+            <groupId>org.apache.geronimo.specs</groupId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/redhat/pantheon/model/Module.java
+++ b/src/main/java/com/redhat/pantheon/model/Module.java
@@ -1,0 +1,109 @@
+package com.redhat.pantheon.model;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Via;
+import org.apache.sling.models.annotations.via.ChildResource;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Calendar;
+
+/**
+ * Model class to represent modules
+ */
+@Model(
+    adaptables = Resource.class,
+    defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class Module {
+
+    @Inject @Named("sling:resourceType")
+    @Default(values = "pantheon/modules")
+    private String slingResourceType;
+
+    @Inject @Named("jcr:created")
+    private Calendar created;
+
+    @Inject @Named("jcr:createdBy")
+    private String createdBy;
+
+    @Inject @Named("jcr:primaryType")
+    private String primaryType;
+
+    @Inject @Named("jcr:data")
+    @Via(value = "asciidoc/jcr:content", type = ChildResource.class)
+    private String asciidocContent;
+
+    @Inject @Named("jcr:data")
+    @Via(value = "cachedContent", type = ChildResource.class)
+    private String cachedHtmlContent;
+
+    @Inject
+    private CachedContent cachedContent;
+
+    public String getSlingResourceType() {
+        return slingResourceType;
+    }
+
+    public Calendar getCreated() {
+        return created;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public String getPrimaryType() {
+        return primaryType;
+    }
+
+    public String getAsciidocContent() {
+        return asciidocContent;
+    }
+
+    public String getCachedHtmlContent() {
+        return cachedHtmlContent;
+    }
+
+    public void setCachedHtmlContent(String cachedHtmlContent) {
+        this.cachedHtmlContent = cachedHtmlContent;
+    }
+
+    public CachedContent getCachedContent() {
+        return cachedContent;
+    }
+
+    /**
+     * Model class to represent a Module's cached html content.
+     * It is a nested class under Module as it only makes sense
+     * for these nodes to be generated under a Module.
+     */
+    @Model(adaptables = Resource.class,
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+    public static class CachedContent {
+
+        @Inject @Named("pant:hash")
+        private String hash;
+
+        @Inject @Named("jcr:data")
+        private String data;
+
+        public String getHash() {
+            return hash;
+        }
+
+        public void setHash(String hash) {
+            this.hash = hash;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+    }
+}

--- a/src/main/java/com/redhat/pantheon/servlet/AsciidocContentRenderingServlet.java
+++ b/src/main/java/com/redhat/pantheon/servlet/AsciidocContentRenderingServlet.java
@@ -1,5 +1,6 @@
 package com.redhat.pantheon.servlet;
 
+import com.redhat.pantheon.model.Module;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
@@ -9,6 +10,8 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -29,15 +32,17 @@ import java.io.Writer;
         }
 )
 public class AsciidocContentRenderingServlet extends SlingSafeMethodsServlet {
+
+    private final Logger log = LoggerFactory.getLogger(AsciidocContentRenderingServlet.class);
+
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         Resource resource = request.getResource();
+        Module module = resource.adaptTo(Module.class);
 
-        String content = resource.getValueMap().get("pantheon:asciidocContent", String.class);
-
-        response.setContentType("text/adoc");
+        response.setContentType("html");
         Writer w = response.getWriter();
-        w.write(content);
+        w.write(module.getAsciidocContent());
     }
 }

--- a/src/main/java/com/redhat/pantheon/servlet/AsciidocRenderingServlet.java
+++ b/src/main/java/com/redhat/pantheon/servlet/AsciidocRenderingServlet.java
@@ -23,6 +23,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.redhat.pantheon.dependency.DependencyProvider;
 import com.redhat.pantheon.dependency.OsgiDependencyProvider;
+import com.redhat.pantheon.model.Module;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.PersistenceException;
@@ -37,8 +38,6 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -74,17 +73,16 @@ public class AsciidocRenderingServlet extends SlingSafeMethodsServlet {
             IOException {
         Resource resource = request.getResource();
         String html = "NO CONTENT";
-
-        // Get the existing content
-        Resource cachedContentNode = resource.getChild(CACHE_NODE_NAME);
+        final Module module = resource.adaptTo(Module.class);
+        String cachedContent = module.getCachedHtmlContent();
 
         // If the content doesn't exist yet, generate and save it
-        if( cachedContentNode == null || !generatedContentHashMatches(resource) || request.getParameter("rerender") != null) {
+        if( cachedContent == null || !generatedContentHashMatches(resource) || request.getParameter("rerender") != null) {
             Content c = generateHtml(request, resource);
-            cacheContent(request, resource, c);
+            cacheContent(request, module, c);
             html = c.html;
         } else {
-            html = cachedContentNode.getValueMap().get("jcr:data", String.class);
+            html = module.getCachedHtmlContent();
         }
 
         response.setContentType("text/html");
@@ -104,7 +102,9 @@ public class AsciidocRenderingServlet extends SlingSafeMethodsServlet {
 
     private Content generateHtml(SlingHttpServletRequest request, Resource resource) throws PersistenceException, IOException {
         Content c = new Content();
-        c.asciidoc = resource.getChild(ADOC_NODE_NAME).getChild(CONTENT_NODE_NAME).getValueMap().get("jcr:data", String.class);
+        // TODO remove the use of Resource (if possible)
+        Module module = resource.adaptTo(Module.class);
+        c.asciidoc = module.getAsciidocContent();
 
         // build the attributes (default + those coming from http parameters)
         AttributesBuilder atts = AttributesBuilder.attributes()
@@ -147,13 +147,12 @@ public class AsciidocRenderingServlet extends SlingSafeMethodsServlet {
         return c;
     }
 
-    private void cacheContent(SlingHttpServletRequest request, Resource resource, Content content) {
+    private void cacheContent(SlingHttpServletRequest request, Module module, Content content) {
         try {
-            Node resourceNode = resource.adaptTo(Node.class);
-            Node cacheNode = resourceNode.getNode(CACHE_NODE_NAME);
-
-            cacheNode.setProperty("pant:hash", hash(content.asciidoc).toString());
-            cacheNode.setProperty("jcr:data", content.html);
+            module.getCachedContent()
+                .setHash(hash(content.asciidoc).toString());
+            module.getCachedContent()
+                .setData(content.html);
 
 //            Session ses = request.getResourceResolver().adaptTo(Session.class);
 //            System.out.println("Session: " + ses);

--- a/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
@@ -1,6 +1,8 @@
 package com.redhat.pantheon.servlet;
 
 import com.redhat.pantheon.dependency.DependencyProvider;
+import com.redhat.pantheon.model.Module;
+import com.redhat.pantheon.model.Module.CachedContent;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sun.misc.Cache;
 
 import javax.jcr.Node;
 import java.io.File;
@@ -46,11 +49,8 @@ public class AsciidocRenderingServletTest {
     public void testGenerateHtmlFromAsciidoc() throws Exception {
 
         // Given
-        Resource contentResource = mock(Resource.class);
-        Node contentNode = mock(Node.class);
-        Node cacheNode = mock(Node.class);
-        Resource fileNode = mock(Resource.class);
-        ValueMap contentNodeVm = mock(ValueMap.class);
+        Module module = mock(Module.class);
+        CachedContent cachedContent = mock(CachedContent.class);
         String asciidocContent = "== This is a title \n\n And this is some text";
         AsciidocRenderingServlet servlet = new AsciidocRenderingServlet();
         servlet.setDependencyProvider(new DependencyProvider() {
@@ -84,13 +84,9 @@ public class AsciidocRenderingServletTest {
 
         // When
         lenient().when(resource.getPath()).thenReturn("/content");
-        lenient().when(resource.adaptTo(Node.class)).thenReturn(contentNode);
-        lenient().when(contentNode.getNode("cachedContent")).thenReturn(cacheNode);
-        lenient().when(resource.getChild("asciidoc")).thenReturn(contentResource);
-        lenient().when(contentResource.getChild("jcr:content")).thenReturn(fileNode);
-        lenient().when(resource.getChild("cachedContent")).thenReturn(null);
-        when(fileNode.getValueMap()).thenReturn(contentNodeVm);
-        when(contentNodeVm.get( eq("jcr:data"), eq(String.class) )).thenReturn( asciidocContent );
+        lenient().when(resource.adaptTo(Module.class)).thenReturn(module);
+        lenient().when(module.getCachedContent()).thenReturn(cachedContent);
+        lenient().when(module.getAsciidocContent()).thenReturn(asciidocContent);
         slingContext.request().setResource(resource);
 
         servlet.doGet(slingContext.request(), slingContext.response());

--- a/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
@@ -5,7 +5,6 @@ import com.redhat.pantheon.model.Module;
 import com.redhat.pantheon.model.Module.CachedContent;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.MockSling;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
@@ -14,9 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import sun.misc.Cache;
 
-import javax.jcr.Node;
 import java.io.File;
 import java.io.IOException;
 import java.net.JarURLConnection;
@@ -29,10 +26,8 @@ import java.util.jar.JarFile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 public class AsciidocRenderingServletTest {


### PR DESCRIPTION
Enable the sling models functionality on this application. Also create an initial version of a Module model to statically map all the properties of modules from our model.
Models help by putting all mapping information (from JCR to java classes) into a single place. If adopted, no code should use the JCR or sling resource apis going forward. 