### PR TITLE
Initial backend search in html

### DIFF
--- a/src/main/resources/apps/pantheon/modules/all/html.html
+++ b/src/main/resources/apps/pantheon/modules/all/html.html
@@ -10,6 +10,10 @@
         <a class="btn btn-primary" href="/modules.add.html">New Module</a>
     </p>
 
+    <p>
+    <input type="text" id="searchTerms" onkeyup="search()" placeholder="Search for names..">
+    </p>
+
     <table id="myTable">
         <tr>
             <th width="200px"><a href="#" onclick="sortTable(0)">Name</a></th>
@@ -19,6 +23,8 @@
             <th><a href="#" onclick="sortTable(4)">Upload Time</a></th>
         </tr>
 
+<sly data-sly-test.searchIsNull="${!request.requestParameterMap['search']}"></sly> 
+  <sly data-sly-use.moduleData="${'com.redhat.pantheon.use.ModuleData' @ query=(searchIsNull ? '*' : request.requestParameterMap['search'][0].toString )}">
         <sly data-sly-list="${moduleData.getModulesCreateSort}">
             <tr>
                 <td>
@@ -37,7 +43,7 @@
                     <sly data-sly-use.date="${'com.redhat.pantheon.use.DateFormatter' @ format='yyyy/MM/dd HH:mm:ss', date=item.jcr:created}">${date.value}</sly>
                 </td>
             </tr>
-        </sly>
+        </sly></sly>
     </table>
 </div>
 
@@ -89,6 +95,26 @@ function sortTable(n) {
   }
 }
 </script>
+<script>
+function search() {
+  // Declare variables
+  var input;
+  //mySearchTerm = input/filter
 
+  document.getElementById("searchTerms")
+    .addEventListener("keyup", function(event) {
+    event.preventDefault();
+    if (event.keyCode === 13) {
+    	  input = document.getElementById("searchTerms");
+    	  //refresh table
+    	  if ('URLSearchParams' in window) {
+    	      var searchParams = new URLSearchParams(window.location.search);
+    	      searchParams.set("search", input.value);
+    	      window.location.search = searchParams.toString();
+    	  }
+    }
+});
+}
+</script>
 </body>
 </html>

--- a/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/AsciidocRenderingServletTest.java
@@ -4,6 +4,7 @@ import com.redhat.pantheon.conf.AsciidoctorPoolService;
 import com.redhat.pantheon.conf.LocalFileManagementService;
 import com.redhat.pantheon.model.Module;
 import com.redhat.pantheon.model.Module.CachedContent;
+import com.redhat.pantheon.use.ModuleData;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.MockSling;
@@ -22,6 +23,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -70,6 +72,22 @@ public class AsciidocRenderingServletTest {
         assertTrue(slingContext.response().getOutputAsString().contains("This is a title"));
         assertTrue(slingContext.response().getOutputAsString().contains("And this is some text"));
         assertEquals("text/html", slingContext.response().getContentType());
+    }
+
+    @Test
+    @DisplayName("Search for available modules")
+    public void testSearchAvailableModules() throws Exception {
+        // Given
+    	//TO-DO Need to figure out way to add modules to mock.
+
+        // When
+        // Normally this is instantiated thru sly in the html
+    	ModuleData moduleData = mock(ModuleData.class);
+        List<Map<String, Object>> data = moduleData.getModulesCreateSort();
+
+        // Then
+        //We Expect an empty list because we have not added any modules.
+        assertEquals("[]", data.toString());
     }
 
     private List<String> getGemPaths() throws IOException {


### PR DESCRIPTION
Initial backend search, will build on top of this with a front-end framework next.

Note, I changed a few variables and methods to static to be able to grab the data from sly/htl at any point on  src/main/java/com/redhat/pantheon/use/ModuleData.java .

The javax.script.Bindings don't get passed down to the class when I create a new instance of the class, it looks like it they get populated at app start by sling. By making it static I make sure the bindings that populate the resolver variable at init() are are accessible when I do each search.

Simple test case added to build on top of it later too.