### PR TITLE
modularize access to the JCR repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,5 +424,11 @@
             <version>2.3.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+            <version>2.1.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
+++ b/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
@@ -1,16 +1,19 @@
 package com.redhat.pantheon.data;
 
+import com.redhat.pantheon.jcr.JcrQueryHelper;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.query.Query;
-import java.util.ArrayList;
+import javax.jcr.RepositoryException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Created by ben on 4/18/19.
@@ -27,19 +30,28 @@ public class ModuleDataRetriever {
     }
 
     public List<Map<String, Object>> getModulesNameSort(String searchTerm) {
-        return getModules(searchTerm, "order by a.[jcr:title] asc");
+        try {
+            return getModules(searchTerm, "a.[jcr:title] asc");
+        } catch (RepositoryException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<Map<String, Object>> getModulesCreateSort(String searchTerm) {
-        return getModules(searchTerm, "order by a.[jcr:created] desc");
+        try {
+            return getModules(searchTerm, "a.[jcr:created] desc");
+        } catch (RepositoryException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    private List<Map<String, Object>> getModules(String query, String querySuffix) {
+    private List<Map<String, Object>> getModules(String query, String orderBy)
+            throws RepositoryException {
         if (query.equals("") || query.equals("*") || query == null) {
             query = "";
         } else {
-            query = "AND (a.[jcr:title] like "+ "'%"+query+"%' "+
-                    "OR a.[jcr:description] like "+ "'%"+query+"%') ";
+            query = "AND (a.[jcr:title] like " + "'%" + query + "%' " +
+                    "OR a.[jcr:description] like " + "'%" + query + "%') ";
         }
 
         //FIXME - we had "select * from [pant:module]..." here, BUT we were seeing problems that after a very small
@@ -47,19 +59,21 @@ public class ModuleDataRetriever {
         //FIXME - of modules. Changing this to [nt:base] seems to fix it, but I don't know why. Perhaps it's some bug
         //FIXME - related to 'nodetypes.cnd' getting reinstalled on every package deployment, resulting in the
         //FIXME - pant:module nodetype being assigned some new internal id, but that's pure speculation.
-        Iterator<Resource> resources = resolver.findResources("select * from [nt:base] as a " +
-                "where [sling:resourceType] = 'pantheon/modules' " +
-                "and (isdescendantnode(a, '/content/repositories') " +
-                "or isdescendantnode(a, '/content/modules') " +
-                "or isdescendantnode(a, '/content/sandboxes')) " + query +
-                querySuffix, Query.JCR_SQL2);
+        StringBuilder queryBuilder = new StringBuilder()
+                .append("select * from [nt:base] as a ")
+                .append("where [sling:resourceType] = 'pantheon/modules' ")
+                .append("and (isdescendantnode(a, '/content/repositories') ")
+                .append("or isdescendantnode(a, '/content/modules') ")
+                .append("or isdescendantnode(a, '/content/sandboxes')) ")
+                .append(query);
+        if (!isEmpty(orderBy)) {
+            queryBuilder.append("order by").append(orderBy);
+        }
 
-        List<Map<String, Object>> ret = new ArrayList<>();
+        Stream<Resource> results = new JcrQueryHelper(resolver).query(queryBuilder.toString());
 
-        while (resources.hasNext()) {
-            Resource r = resources.next();
+        return results.map(r -> {
             Map<String, Object> m = new HashMap(r.getValueMap());
-            ret.add(m);
             log.trace(r.getName());
             m.put("name", r.getName());
             m.put("pant:transientPath", r.getPath().substring(PATH_SUBSTRING_INDEX));
@@ -74,8 +88,8 @@ public class ModuleDataRetriever {
                 log.trace("{} :: {} :: {}", e.getKey(), e.getValue().getClass(), e.getValue());
             }
             log.trace("");
-        }
-
-        return ret;
+            return m;
+        })
+        .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
+++ b/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
@@ -67,7 +67,7 @@ public class ModuleDataRetriever {
                 .append("or isdescendantnode(a, '/content/sandboxes')) ")
                 .append(query);
         if (!isEmpty(orderBy)) {
-            queryBuilder.append("order by").append(orderBy);
+            queryBuilder.append(" order by ").append(orderBy);
         }
 
         Stream<Resource> results = new JcrQueryHelper(resolver).query(queryBuilder.toString());

--- a/src/main/java/com/redhat/pantheon/jcr/JcrQueryHelper.java
+++ b/src/main/java/com/redhat/pantheon/jcr/JcrQueryHelper.java
@@ -1,0 +1,64 @@
+package com.redhat.pantheon.jcr;
+
+import com.google.common.collect.Lists;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Provides utility methods for querying the Sling JCR repository.
+ */
+public class JcrQueryHelper {
+
+    private final ResourceResolver resourceResolver;
+
+    public JcrQueryHelper(ResourceResolver resourceResolver) {
+        this.resourceResolver = resourceResolver;
+    }
+
+    /**
+     * A convenience method to run a query against the JCR Repository adding limit and offset values useful for
+     * pagination.
+     * @param query A full JCR SQL2 query
+     * @param limit the number of results to return (for pagination)
+     * @param offset i.e. How many results to skip (for pagination)
+     * @return
+     * @throws RepositoryException
+     */
+    public Stream<Resource> query(String query, long limit, long offset)
+            throws RepositoryException {
+        Session session = resourceResolver.adaptTo(Session.class);
+
+        QueryManager queryManager = session.getWorkspace().getQueryManager();
+        Query queryObj = queryManager.createQuery(query, Query.JCR_SQL2);
+        queryObj.setLimit(limit);
+        queryObj.setOffset(offset);
+        QueryResult result = queryObj.execute();
+
+        // Transform to sling resources
+        // TODO This might be a costly transformation if done on large result sets
+        return Lists.newArrayList((Iterator<Row>) result.getRows())
+                .stream()
+                .map(row -> {
+                    try {
+                        return resourceResolver.getResource(row.getPath());
+                    } catch (RepositoryException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    public Stream<Resource> query(String query)
+            throws RepositoryException {
+        return query(query, -1, 0);
+    }
+
+}

--- a/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
+++ b/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
@@ -28,6 +28,6 @@
 <pant = 'http://redhat.com/pantheon'>
 
 // Base type for modules
-[pant:module] > nt:unstructured, sling:Folder
+[pant:module] > nt:unstructured
 	- sling:resourceType (string) = 'pantheon/modules' mandatory autocreated
     + cachedContent (nt:unstructured) = nt:unstructured mandatory autocreated

--- a/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
+++ b/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
@@ -1,22 +1,25 @@
 package com.redhat.pantheon.data;
 
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
-import org.apache.sling.testing.resourceresolver.MockResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.jcr.query.Query;
-import java.util.Collections;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import java.util.List;
 import java.util.Map;
 
 import static com.beust.jcommander.internal.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
+import static org.apache.sling.testing.mock.jcr.MockJcr.setQueryResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -24,9 +27,28 @@ import static org.mockito.Mockito.*;
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 public class ModuleDataRetrieverTest {
 
-    @Mock
+    private final SlingContext slingContext = new SlingContext();
     private ResourceResolver resourceResolver;
 
+    @BeforeEach
+    public void prepareTest() {
+        // Need to spy the object as mock sling doesn't seem to be properly registering adapter functions
+        resourceResolver = spy(slingContext.resourceResolver());
+    }
+
+    @AfterEach
+    public void cleanUpTest() {
+    }
+
+    private static Node mockNode(String path) {
+        Node mockNode = mock(Node.class);
+        try {
+            when(mockNode.getPath()).thenReturn(path);
+        } catch (RepositoryException e) {
+            throw new RuntimeException(e);
+        }
+        return mockNode;
+    }
 
     @Test
     @DisplayName("Search for available modules and get empty results")
@@ -35,9 +57,8 @@ public class ModuleDataRetrieverTest {
         ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
 
         // When
+        when(resourceResolver.adaptTo(Session.class)).thenReturn(MockJcr.newSession());
         // Normally this is instantiated thru sly in the html
-        lenient().when(resourceResolver.findResources(anyString(), eq(Query.JCR_SQL2)))
-                .thenReturn(Collections.emptyIterator());
         List<Map<String, Object>> createSortResults = retriever.getModulesCreateSort("any search term");
         List<Map<String, Object>> nameSortResults = retriever.getModulesNameSort("any search term");
 
@@ -51,16 +72,23 @@ public class ModuleDataRetrieverTest {
     @DisplayName("Search for available modules sorted by creation date")
     public void testSearchModulesCreateSort() throws Exception {
         // Given
-        final List<Resource> resources = newArrayList(
-                new MockResource("/content/repos/test/module1", newHashMap(), resourceResolver),
-                new MockResource("/content/repos/test/module2", newHashMap(), resourceResolver),
-                new MockResource("/content/repos/test/module3", newHashMap(), resourceResolver)
-        );
+        slingContext.build()
+                .resource("/content/repos/test/module1", newHashMap())
+                .resource("/content/repos/test/module2", newHashMap())
+                .resource("/content/repos/test/module3", newHashMap())
+                .commit();
+        Session mockSession = MockJcr.newSession();
         ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
 
         // When
-        lenient().when(resourceResolver.findResources(anyString(), eq(Query.JCR_SQL2)))
-                .thenReturn(resources.iterator());
+        when(resourceResolver.adaptTo(Session.class)).thenReturn(mockSession);
+        setQueryResult(mockSession,
+                newArrayList(
+                        mockNode("/content/repos/test/module1"),
+                        mockNode("/content/repos/test/module2"),
+                        mockNode("/content/repos/test/module3")
+                )
+        );
         List<Map<String, Object>> results = retriever.getModulesCreateSort("any search term");
 
         // Then
@@ -71,16 +99,23 @@ public class ModuleDataRetrieverTest {
     @DisplayName("Search for available modules sorted by name")
     public void testSearchModulesNameSort() throws Exception {
         // Given
-        final List<Resource> resources = newArrayList(
-                new MockResource("/content/repos/test/module1", newHashMap(), resourceResolver),
-                new MockResource("/content/repos/test/module2", newHashMap(), resourceResolver),
-                new MockResource("/content/repos/test/module3", newHashMap(), resourceResolver)
-        );
+        slingContext.build()
+                .resource("/content/repos/test/module1", newHashMap())
+                .resource("/content/repos/test/module2", newHashMap())
+                .resource("/content/repos/test/module3", newHashMap())
+                .commit();
+        Session mockSession = MockJcr.newSession();
         ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
 
         // When
-        lenient().when(resourceResolver.findResources(anyString(), eq(Query.JCR_SQL2)))
-                .thenReturn(resources.iterator());
+        when(resourceResolver.adaptTo(Session.class)).thenReturn(mockSession);
+        setQueryResult(mockSession,
+                newArrayList(
+                        mockNode("/content/repos/test/module1"),
+                        mockNode("/content/repos/test/module2"),
+                        mockNode("/content/repos/test/module3")
+                )
+        );
         List<Map<String, Object>> results = retriever.getModulesNameSort("any search term");
 
         // Then

--- a/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
+++ b/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.data;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -17,9 +18,6 @@ import javax.jcr.Session;
 import java.util.List;
 import java.util.Map;
 
-import static com.beust.jcommander.internal.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
-import static org.apache.sling.testing.mock.jcr.MockJcr.setQueryResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -27,7 +25,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 public class ModuleDataRetrieverTest {
 
-    private final SlingContext slingContext = new SlingContext();
+    // Running with a full JCR implementation
+    private final SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
     private ResourceResolver resourceResolver;
 
     @BeforeEach
@@ -73,23 +72,17 @@ public class ModuleDataRetrieverTest {
     public void testSearchModulesCreateSort() throws Exception {
         // Given
         slingContext.build()
-                .resource("/content/repos/test/module1", newHashMap())
-                .resource("/content/repos/test/module2", newHashMap())
-                .resource("/content/repos/test/module3", newHashMap())
+                .resource("/content/modules/test/module1",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module2",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module3",
+                        "sling:resourceType", "pantheon/modules")
                 .commit();
-        Session mockSession = MockJcr.newSession();
         ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
 
         // When
-        when(resourceResolver.adaptTo(Session.class)).thenReturn(mockSession);
-        setQueryResult(mockSession,
-                newArrayList(
-                        mockNode("/content/repos/test/module1"),
-                        mockNode("/content/repos/test/module2"),
-                        mockNode("/content/repos/test/module3")
-                )
-        );
-        List<Map<String, Object>> results = retriever.getModulesCreateSort("any search term");
+        List<Map<String, Object>> results = retriever.getModulesCreateSort("");
 
         // Then
         assertEquals(3, results.size());
@@ -100,23 +93,17 @@ public class ModuleDataRetrieverTest {
     public void testSearchModulesNameSort() throws Exception {
         // Given
         slingContext.build()
-                .resource("/content/repos/test/module1", newHashMap())
-                .resource("/content/repos/test/module2", newHashMap())
-                .resource("/content/repos/test/module3", newHashMap())
+                .resource("/content/modules/test/module1",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module2",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module3",
+                        "sling:resourceType", "pantheon/modules")
                 .commit();
-        Session mockSession = MockJcr.newSession();
         ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
 
         // When
-        when(resourceResolver.adaptTo(Session.class)).thenReturn(mockSession);
-        setQueryResult(mockSession,
-                newArrayList(
-                        mockNode("/content/repos/test/module1"),
-                        mockNode("/content/repos/test/module2"),
-                        mockNode("/content/repos/test/module3")
-                )
-        );
-        List<Map<String, Object>> results = retriever.getModulesNameSort("any search term");
+        List<Map<String, Object>> results = retriever.getModulesNameSort("");
 
         // Then
         assertEquals(3, results.size());

--- a/src/test/java/com/redhat/pantheon/jcr/JcrQueryHelperTest.java
+++ b/src/test/java/com/redhat/pantheon/jcr/JcrQueryHelperTest.java
@@ -1,0 +1,180 @@
+package com.redhat.pantheon.jcr;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith({SlingContextExtension.class, MockitoExtension.class})
+public class JcrQueryHelperTest {
+
+    // Testing with a real JCR repository
+    private final SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Test
+    @DisplayName("Test queryAll simple call")
+    public void testQueryAll() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+        .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.queryAll("pant:module");
+
+        // Then
+        assertEquals(1, results.count());
+    }
+
+    @Test
+    @DisplayName("Test queryAll with limit")
+    public void testQueryAllWithLimit() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module2",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module3",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module4",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module5",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.queryAll("pant:module", 3, 0);
+
+        // Then
+        List<Resource> resultList = results.collect(Collectors.toList());
+        assertEquals(3, resultList.size());
+        assertEquals("/content/module1", resultList.get(0).getPath());
+        assertEquals("/content/module2", resultList.get(1).getPath());
+        assertEquals("/content/module3", resultList.get(2).getPath());
+    }
+
+    @Test
+    @DisplayName("Test queryAll with an offset")
+    public void testQueryAllWithOffset() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module2",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module3",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module4",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module5",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.queryAll("pant:module", Long.MAX_VALUE, 2);
+
+        // Then
+        List<Resource> resultList = results.collect(Collectors.toList());
+        assertEquals(3, resultList.size());
+        assertEquals("/content/module3", resultList.get(0).getPath());
+        assertEquals("/content/module4", resultList.get(1).getPath());
+        assertEquals("/content/module5", resultList.get(2).getPath());
+    }
+
+    @Test
+    @DisplayName("Test queryAll with an offset and a limit")
+    public void testQueryAllWithOffsetAndLimits() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module2",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module3",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module4",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module5",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.queryAll("pant:module", 2, 2);
+
+        // Then
+        List<Resource> resultList = results.collect(Collectors.toList());
+        assertEquals(2, resultList.size());
+        assertEquals("/content/module3", resultList.get(0).getPath());
+        assertEquals("/content/module4", resultList.get(1).getPath());
+    }
+
+    @Test
+    @DisplayName("Test query")
+    public void testQuery() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module2",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module3",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module4",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module5",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.query("select * from [pant:module]");
+
+        // Then
+        List<Resource> resultList = results.collect(Collectors.toList());
+        assertEquals(5, resultList.size());
+    }
+
+    @Test
+    @DisplayName("Test query with limits and offset")
+    public void testQueryWithLimitsAndOffset() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module2",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module3",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module4",
+                        "jcr:primaryType", "pant:module")
+                .resource("/content/module5",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        JcrQueryHelper helper = new JcrQueryHelper(slingContext.resourceResolver());
+
+        // When
+        Stream<Resource> results = helper.query("select * from [pant:module] as m order by [jcr:path]", 2, 2);
+
+        // Then
+        List<Resource> resultList = results.collect(Collectors.toList());
+        assertEquals(2, resultList.size());
+        assertEquals("/content/module3", resultList.get(0).getPath());
+        assertEquals("/content/module4", resultList.get(1).getPath());
+    }
+}

--- a/src/test/resources/META-INF/MANIFEST.MF
+++ b/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Sling-Nodetypes: SLING-INF/nodetypes/nodetypes.cnd


### PR DESCRIPTION
Add the `JcrQueryHelper` class to help with JCR repository access (e.g. with utilities for pagination) and their corresponding unit tests.
Use an in-memory JCR repository for unit tests. This will represent a cost in terms of test startup time, but will increase the coverage and depth of the unit tests.
Modify the `ModuleDataRetreiver` class to use this new helper class.