### PR TITLE
add codecov reports for javascript sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ jdk: openjdk8
 install: true
 script: ./mvnw clean install
 after_success:
-  # Move the code coverage results to codecov
-- bash <(curl -s https://codecov.io/bash)
+# Move the code coverage results to codecov
+- bash <(curl -s https://codecov.io/bash) -cF java
+- bash <(curl -s https://codecov.io/bash) -cF javascript
 cache:
   directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </properties>
 
     <build>
-    <!--Copies React dist to the content directory to be later added to the JCR-->
+        <!--Copies React dist to the content directory to be later added to the JCR-->
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -48,7 +48,7 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
-    
+
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -161,47 +161,47 @@
                 </executions>
             </plugin>
             <plugin>
-    <groupId>com.github.eirslett</groupId>
-    <artifactId>frontend-maven-plugin</artifactId>
-    <version>${frontend-maven-plugin.version}</version>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
 
-    <configuration>
-        <nodeVersion>${node.version}</nodeVersion>
-        <yarnVersion>${yarn.version}</yarnVersion>
-        <workingDirectory>${frontendSrcDir}</workingDirectory>
-        <installDirectory>${project.build.directory}</installDirectory>
-    </configuration>
+                <configuration>
+                    <nodeVersion>${node.version}</nodeVersion>
+                    <yarnVersion>${yarn.version}</yarnVersion>
+                    <workingDirectory>${frontendSrcDir}</workingDirectory>
+                    <installDirectory>${project.build.directory}</installDirectory>
+                </configuration>
 
-    <executions>
-        <execution>
-            <id>install-frontend-tools</id>
-            <goals>
-                <goal>install-node-and-yarn</goal>
-            </goals>
-        </execution>
+                <executions>
+                    <execution>
+                        <id>install-frontend-tools</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                    </execution>
 
-        <execution>
-            <id>yarn-install</id>
-            <goals>
-                <goal>yarn</goal>
-            </goals>
-            <configuration>
-                <arguments>install</arguments>
-            </configuration>
-        </execution>
+                    <execution>
+                        <id>yarn-install</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
 
-        <execution>
-            <id>build-frontend</id>
-            <goals>
-                <goal>yarn</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-                <arguments>build</arguments>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
+                    <execution>
+                        <id>build-frontend</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,17 @@
                             <arguments>build</arguments>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>yarn-test</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <arguments>test</arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Enable code coverage reports for javascript to be sent out to codecov. The coverage reports will now be cumulative (js + java). The front end's test phase has been enabled to run in maven's test phase.

Also corrected some indentation issues on the pom.xml file, which will make this change a bit ugly.