### PR TITLE
enable personal sandboxes for hosting content

### DIFF
--- a/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
+++ b/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
@@ -79,7 +79,7 @@ public class ModuleDataRetriever {
                 .append("where [sling:resourceType] = 'pantheon/modules' ")
                 .append("and (isdescendantnode(a, '/content/repositories') ")
                 .append("or isdescendantnode(a, '/content/modules') ")
-                .append("or isdescendantnode(a, '/content/sandboxes')) ")
+                .append("or isdescendantnode(a, '/content/sandbox')) ")
                 .append(query);
         if (!isEmpty(orderByKey) && !isEmpty(orderByDirection)) {
             queryBuilder.append(" order by a.[").append(orderByKey).append("] ").append(orderByDirection);

--- a/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
+++ b/src/main/java/com/redhat/pantheon/data/ModuleDataRetriever.java
@@ -31,9 +31,6 @@ public class ModuleDataRetriever {
 
 	public List<Map<String, Object>> getModulesSort(String searchTerm, String key, String direction,
                                                     long offset, long limit) throws RepositoryException {
-		if (searchTerm == null || searchTerm.isEmpty()) {
-			searchTerm.equals("*");
-		}
 		if (key == null || (!key.equals("jcr:title") && !key.equals("jcr:description"))) {
 			key = "jcr:created";
 		}
@@ -61,7 +58,7 @@ public class ModuleDataRetriever {
 
     private List<Map<String, Object>> getModules(String query, String orderByKey, String orderByDirection, Long offset, Long limit)
             throws RepositoryException {
-        if (query.equals("") || query.equals("*") || query == null) {
+        if (query == null || query.equals("") || query.equals("*")) {
             query = "";
         } else {
             query=query.replace('*','%');

--- a/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
+++ b/src/test/java/com/redhat/pantheon/data/ModuleDataRetrieverTest.java
@@ -39,16 +39,6 @@ public class ModuleDataRetrieverTest {
     public void cleanUpTest() {
     }
 
-    private static Node mockNode(String path) {
-        Node mockNode = mock(Node.class);
-        try {
-            when(mockNode.getPath()).thenReturn(path);
-        } catch (RepositoryException e) {
-            throw new RuntimeException(e);
-        }
-        return mockNode;
-    }
-
     @Test
     @DisplayName("Search for available modules and get empty results")
     public void testSearchAvailableModulesEmptyResult() throws Exception {
@@ -65,6 +55,28 @@ public class ModuleDataRetrieverTest {
         //We Expect an empty list because we have not added any modules.
         assertTrue(createSortResults.isEmpty());
         assertTrue(nameSortResults.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Search for modules with a null search term")
+    public void testSearchModulesNullArgs() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/content/modules/test/module1",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module2",
+                        "sling:resourceType", "pantheon/modules")
+                .resource("/content/modules/test/module3",
+                        "sling:resourceType", "pantheon/modules")
+                .commit();
+        ModuleDataRetriever retriever = new ModuleDataRetriever(resourceResolver);
+
+        // When
+        List<Map<String, Object>> results = retriever.getModulesSort(null, null, null, 0, 10);
+
+        // Then
+        // should return all modules
+        assertEquals(3, results.size());
     }
 
     @Test


### PR DESCRIPTION
Enable the use of sandboxes by any registered pantheon user. Sandboxes will be hosted under the `/content/sandbox` path, and the uploader will force the sandbox name to be that of the authenticated user. e.g. `/content/sandbox/<username>`

The uploader adds a `--sandbox` parameter (or `-b` for short) which may be used to specify that a push goes to the sandbox. Example usage:

`pantheon push -b -u user -p password` 

This would execute a push to the user's sandbox located at `/content/sandbox/user`.

Additional changes in this revision:
Reduced the amount of logging done by the uploader (i.e. removed the logging of non-uploaded files)
Added terminal colors for certain log entries to easily determine where there is a problem.

What this pull request does not contain:
Currently there is no way to restrict pushing to another user's sandbox. The uploader will prevent it, but there's no REST API security restriction in place.
Sandbox content is visible to all users, not just the user's own sandbox.
