### PR TITLE
add a metadata extractor

### DIFF
--- a/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorPool.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorPool.java
@@ -20,7 +20,7 @@ import org.osgi.service.component.annotations.*;
 public class AsciidoctorPool extends ObjectPool<Asciidoctor> {
 
     // Hardcoding these values for now
-    protected static final int INITIAL_SIZE = 5;
+    protected static final int INITIAL_SIZE = 1;
     protected static final int MAX_SIZE = 10;
 
     @Activate
@@ -47,6 +47,12 @@ public class AsciidoctorPool extends ObjectPool<Asciidoctor> {
         asciidoctor.javaExtensionRegistry().includeProcessor(
                 new SlingResourceIncludeProcessor(base));
         return asciidoctor;
+    }
+
+    @Override
+    public void returnObject(Asciidoctor obj) {
+        obj.unregisterAllExtensions();
+        super.returnObject(obj);
     }
 
     @Override

--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -1,0 +1,62 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.model.ModuleRevision;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.Treeprocessor;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * A tree processor that extracts metadata from the asciidoc AST and inserts it
+ * into a sling resource.
+ *
+ * <p>
+ * Extracted items include:
+ * <ul>
+ *     <li>Title - the asciidoc document's title</li>
+ *     <li>Abstract - The first paragraph in the asciidoc document</li>
+ * </ul>
+ *
+ * A current restriction is that when the extracted metadata contains variable
+ * substitutions, the substitutions will not be applied when recording the
+ * value in the resource.
+ * </p>
+ *
+ * @author Carlos Munoz
+ */
+public class MetadataExtractorTreeProcessor extends Treeprocessor {
+
+    private final ModuleRevision moduleRevision;
+
+    public MetadataExtractorTreeProcessor(ModuleRevision moduleRevision) {
+        this.moduleRevision = moduleRevision;
+    }
+
+    @Override
+    public Document process(Document document) {
+        extractDocTitle(document);
+        extractAbstract(document);
+        return document;
+    }
+
+    private void extractDocTitle(Document document) {
+        String docTitle = document.getDoctitle();
+        if(!isNullOrEmpty(docTitle)) {
+            moduleRevision.title.set(docTitle);
+        }
+    }
+
+    private void extractAbstract(Document document) {
+        // Abstract is the first paragraph
+        if(document.getBlocks().size() > 0) {
+            StructuralNode firstBlock = document.getBlocks().get(0);
+            if(firstBlock.getContent() != null) {
+                String abstractContent = firstBlock.getContent().toString();
+                if (!isNullOrEmpty(abstractContent)) {
+                    moduleRevision.mAbstract.set(abstractContent);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/redhat/pantheon/model/ModuleRevision.java
+++ b/src/main/java/com/redhat/pantheon/model/ModuleRevision.java
@@ -22,6 +22,8 @@ public class ModuleRevision extends SlingResource {
 
     public final Field<String> title = stringField("jcr:title");
 
+    public final Field<String> mAbstract = stringField("pant:abstract");
+
     public final Field<String> description = stringField("jcr:description");
 
     public final Field<Calendar> created = dateField("jcr:created");

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
@@ -1,0 +1,66 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.model.ModuleRevision;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.asciidoctor.Asciidoctor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith({SlingContextExtension.class, MockitoExtension.class})
+class MetadataExtractorTreeProcessorTest {
+
+    private final SlingContext slingContext = new SlingContext();
+
+    @Test
+    void extractMetadata() {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        Resource moduleRevision = slingContext.resourceResolver().getResource("/content/module1");
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(new ModuleRevision(moduleRevision));
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent = "= A title for content" +
+                "\n" +
+                "\n" +
+                "This is the first paragraph which serves as abstract for a module";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertEquals("A title for content", moduleRevision.getValueMap().get("jcr:title"));
+        assertEquals("This is the first paragraph which serves as abstract for a module",
+                moduleRevision.getValueMap().get("pant:abstract"));
+    }
+
+    @Test
+    void extractMetadataAbstractNotPresent() {
+        // Given
+        slingContext.build()
+                .resource("/content/module1",
+                        "jcr:primaryType", "pant:module")
+                .commit();
+        Resource module = slingContext.resourceResolver().getResource("/content/module1");
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(new ModuleRevision(module));
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent = "= A title for content";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertFalse(module.getValueMap().containsKey("pant:abstract"));
+    }
+}

--- a/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
@@ -4,7 +4,6 @@ import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.servlets.post.HtmlResponse;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +22,7 @@ class ModuleRevisionUploadTest {
     @Test
     void createFirstRevision() {
         // Given
-        ModuleRevisionUpload upload = new ModuleRevisionUpload();
+        ModuleRevisionUpload upload = new ModuleRevisionUpload(null);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
@@ -44,7 +43,7 @@ class ModuleRevisionUploadTest {
                 .resource("/new/module/locales/es_ES/revisions/v1/asciidoc/jcr:content",
                         "jcr:data", "This is the old adoc content")
                 .commit();
-        ModuleRevisionUpload upload = new ModuleRevisionUpload();
+        ModuleRevisionUpload upload = new ModuleRevisionUpload(null);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
@@ -66,7 +65,7 @@ class ModuleRevisionUploadTest {
                 .resource("/new/module/locales/es_ES/revisions/v1/asciidoc/jcr:content",
                         "jcr:data", "This is the old adoc content")
                 .commit();
-        ModuleRevisionUpload upload = new ModuleRevisionUpload();
+        ModuleRevisionUpload upload = new ModuleRevisionUpload(null);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the old adoc content");

--- a/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
@@ -1,28 +1,39 @@
 package com.redhat.pantheon.servlet;
 
+import com.redhat.pantheon.asciidoctor.AsciidoctorPool;
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.servlets.post.HtmlResponse;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.asciidoctor.Asciidoctor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
-@ExtendWith({SlingContextExtension.class})
+@ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 class ModuleRevisionUploadTest {
 
     private SlingContext slingContext = new SlingContext();
 
+    @Mock
+    AsciidoctorPool asciidoctorPool;
+
     @Test
-    void createFirstRevision() {
+    void createFirstRevision() throws Exception {
         // Given
-        ModuleRevisionUpload upload = new ModuleRevisionUpload(null);
+        lenient().when(asciidoctorPool.borrowObject()).thenReturn(mock(Asciidoctor.class, RETURNS_DEEP_STUBS));
+        ModuleRevisionUpload upload = new ModuleRevisionUpload(asciidoctorPool);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
@@ -30,7 +41,7 @@ class ModuleRevisionUploadTest {
         slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/module"));
 
         // when
-        upload.run(slingContext.request(), new HtmlResponse(), null);
+        upload.doRun(slingContext.request(), new HtmlResponse(), null);
 
         // Then
         assertNotNull(slingContext.resourceResolver().getResource("/new/module/locales/es_ES/revisions/v1"));
@@ -43,7 +54,8 @@ class ModuleRevisionUploadTest {
                 .resource("/new/module/locales/es_ES/revisions/v1/asciidoc/jcr:content",
                         "jcr:data", "This is the old adoc content")
                 .commit();
-        ModuleRevisionUpload upload = new ModuleRevisionUpload(null);
+        lenient().when(asciidoctorPool.borrowObject()).thenReturn(mock(Asciidoctor.class, RETURNS_DEEP_STUBS));
+        ModuleRevisionUpload upload = new ModuleRevisionUpload(asciidoctorPool);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");


### PR DESCRIPTION
The metadata extractor is an asciidoctor extension which is capable of extracting metadata from the Asciidoctor AST. In this revision only title and abstract are extracted, and with limitations. The metadata extractor is called after each module revision creation.

This change also fixes a memory leak in the Asciidoctor pool.