### PR TITLE
add an extension mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.event</artifactId>
+            <version>4.2.12</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <artifactId>geronimo-atinject_1.0_spec</artifactId>
             <version>1.1</version>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/src/main/java/com/redhat/pantheon/extension/Event.java
+++ b/src/main/java/com/redhat/pantheon/extension/Event.java
@@ -1,0 +1,11 @@
+package com.redhat.pantheon.extension;
+
+import java.io.Serializable;
+
+/**
+ * Interface which all Events should implement. This is simply a marker interface.
+ *
+ * @author Carlos Munoz
+ */
+public interface Event extends Serializable {
+}

--- a/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
+++ b/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
@@ -1,0 +1,95 @@
+package com.redhat.pantheon.extension;
+
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.consumer.JobConsumer;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * Base class for all Job consumers for fired events. It contains most of the logic necessary to
+ * implement an event job consumer. Since these job consumers are bound to specific extension interfaces,
+ * each concrete implementation will only process one type of extension. Caution must be taken so
+ * that specific extension types are not processed by multiple concrete EventJobConsumers, as the results
+ * would be undefined.
+ *
+ * Subclasses of this are necessary only to declare the right OSGI component configuration so that each
+ * type of event can be sent to a different queue. If this is not desired, this class should be sufficient to
+ * process ALL events from a single queue.
+ * @param <EXT>
+ *
+ * @author Carlos Munoz
+ */
+abstract class EventJobConsumer<EXT extends EventProcessingExtension> implements JobConsumer {
+
+    public static final Logger log = LoggerFactory.getLogger(EventJobConsumer.class);
+
+    /** The specific extension class this job consumer satisfies */
+    protected final Class<EXT> extensionClass;
+
+    protected EventJobConsumer(Class<EXT> extensionClass) {
+        this.extensionClass = extensionClass;
+    }
+
+    /**
+     * Generic method that processes a job. The job will always check for the presence of
+     * an event in the job properties, and an error will be reported if no such property
+     * exists.
+     * @param job The event job to process
+     * @return OK in almost all circumstances, even if some extensions execute incorrectly.
+     */
+    @Override
+    public final JobResult process(final Job job) {
+        final Event firedEvent = job.getProperty(Event.class.getName(), Event.class);
+
+        if (firedEvent == null) {
+            log.error(this.getClass().getName() + " fired an even job with no event");
+            return JobResult.CANCEL;
+        }
+
+        try {
+            getExtensions(EventProcessingExtension.class).forEach(service -> {
+                try {
+                    service.processEvent(firedEvent);
+                    log.trace("Extension " + service.getClass().getName() + " finished successfully");
+                } catch (Throwable t) {
+                    log.warn("Extension " + service.getClass().getName() + " did not execute successfully", t);
+                }
+            });
+        } catch (InvalidSyntaxException e) {
+            // This should not happen since we are not filtering the services (the filter parameter is null)
+            log.error("Invalid filter syntax", e);
+            return JobResult.CANCEL;
+        }
+        return JobResult.OK;
+    }
+
+    /**
+     * Collects all the services registered as implementations of the given interface.
+     *
+     * @param extInterface The extension interface
+     * @param <T>
+     * @return A set of extension services which implement the provided interface.
+     */
+    private static <T> Collection<T> getExtensions(Class<T> extInterface) throws InvalidSyntaxException {
+        List<T> extensions = newArrayList();
+        BundleContext bundleContext = FrameworkUtil.getBundle(extInterface).getBundleContext();
+        Collection<ServiceReference<T>> serviceReferences =
+                bundleContext
+                        .getServiceReferences(extInterface, null);
+
+        for (ServiceReference<T> reference : serviceReferences) {
+            T service = bundleContext.getService(reference);
+            extensions.add(service);
+        }
+        return extensions;
+    }
+}

--- a/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
+++ b/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
@@ -51,7 +51,7 @@ abstract class EventJobConsumer<EXT extends EventProcessingExtension> implements
         final Event firedEvent = job.getProperty(Event.class.getName(), Event.class);
 
         if (firedEvent == null) {
-            log.error(this.getClass().getName() + " fired an even job with no event");
+            log.error(this.getClass().getName() + " fired an event job with no event");
             return JobResult.CANCEL;
         }
 

--- a/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
+++ b/src/main/java/com/redhat/pantheon/extension/EventJobConsumer.java
@@ -56,7 +56,7 @@ abstract class EventJobConsumer<EXT extends EventProcessingExtension> implements
         }
 
         try {
-            getExtensions(EventProcessingExtension.class).forEach(service -> {
+            getExtensions().forEach(service -> {
                 try {
                     service.processEvent(firedEvent);
                     log.trace("Extension " + service.getClass().getName() + " finished successfully");
@@ -75,19 +75,17 @@ abstract class EventJobConsumer<EXT extends EventProcessingExtension> implements
     /**
      * Collects all the services registered as implementations of the given interface.
      *
-     * @param extInterface The extension interface
-     * @param <T>
-     * @return A set of extension services which implement the provided interface.
+     * @return A set of extension services which implement the extension interface for this consumer
      */
-    private static <T> Collection<T> getExtensions(Class<T> extInterface) throws InvalidSyntaxException {
-        List<T> extensions = newArrayList();
-        BundleContext bundleContext = FrameworkUtil.getBundle(extInterface).getBundleContext();
-        Collection<ServiceReference<T>> serviceReferences =
+    protected Collection<EXT> getExtensions() throws InvalidSyntaxException {
+        List<EXT> extensions = newArrayList();
+        BundleContext bundleContext = FrameworkUtil.getBundle(extensionClass).getBundleContext();
+        Collection<ServiceReference<EXT>> serviceReferences =
                 bundleContext
-                        .getServiceReferences(extInterface, null);
+                        .getServiceReferences(extensionClass, null);
 
-        for (ServiceReference<T> reference : serviceReferences) {
-            T service = bundleContext.getService(reference);
+        for (ServiceReference<EXT> reference : serviceReferences) {
+            EXT service = bundleContext.getService(reference);
             extensions.add(service);
         }
         return extensions;

--- a/src/main/java/com/redhat/pantheon/extension/EventProcessingExtension.java
+++ b/src/main/java/com/redhat/pantheon/extension/EventProcessingExtension.java
@@ -1,0 +1,16 @@
+package com.redhat.pantheon.extension;
+
+/**
+ * Common interface for extensions to be triggered after a module publication event occurs in the
+ * system.
+ *
+ * @author Carlos Munoz
+ */
+public interface EventProcessingExtension<E extends Event> {
+
+    /**
+     * Processes an event, or throws an Exception if a problem is encountered.
+     * @throws Exception if there is a problem with event processing
+     */
+    void processEvent(E event) throws Exception;
+}

--- a/src/main/java/com/redhat/pantheon/extension/Events.java
+++ b/src/main/java/com/redhat/pantheon/extension/Events.java
@@ -1,0 +1,53 @@
+package com.redhat.pantheon.extension;
+
+import com.redhat.pantheon.extension.events.ModuleRevisionPublished;
+import com.redhat.pantheon.model.module.ModuleRevision;
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.JobManager;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+/**
+ * Deals with the publication of application events, which are the basis for extensions.
+ * Application events are internally enabled using Sling jobs, and this class makes sure
+ * there are type-safe ways of accessing these extension points.
+ * @author Carlos Munoz
+ */
+@Component(service = Events.class)
+public class Events {
+
+    private static final Logger log = LoggerFactory.getLogger(Events.class);
+    public static final String MODULE_POST_PUBLISH_EVENT = "com/redhat/pantheon/ModulePostPublish";
+
+    private JobManager jobManager;
+
+    @Activate
+    public Events(@Reference JobManager jobManager) {
+        this.jobManager = jobManager;
+    }
+
+    /**
+     * Fires an event indicating that a module revision has been publsihed. As its name implies,
+     * this event should be fired only after a module is published.
+     * @param moduleRevision The module revision which has just been published.
+     */
+    public void fireModuleRevisionPublishedEvent(ModuleRevision moduleRevision) {
+        ModuleRevisionPublished event = new ModuleRevisionPublished(moduleRevision.getPath());
+        Map<String, Object> props = newHashMap();
+        props.put(Event.class.getName(), event);
+        Job job = jobManager.createJob(MODULE_POST_PUBLISH_EVENT)
+                .properties(props)
+                .add();
+
+        if(job == null) {
+            throw new RuntimeException("Something went wrong creating a " + MODULE_POST_PUBLISH_EVENT + " job");
+        }
+    }
+}

--- a/src/main/java/com/redhat/pantheon/extension/Events.java
+++ b/src/main/java/com/redhat/pantheon/extension/Events.java
@@ -1,6 +1,6 @@
 package com.redhat.pantheon.extension;
 
-import com.redhat.pantheon.extension.events.ModuleRevisionPublished;
+import com.redhat.pantheon.extension.events.ModuleRevisionPublishedEvent;
 import com.redhat.pantheon.model.module.ModuleRevision;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
@@ -39,7 +39,7 @@ public class Events {
      * @param moduleRevision The module revision which has just been published.
      */
     public void fireModuleRevisionPublishedEvent(ModuleRevision moduleRevision) {
-        ModuleRevisionPublished event = new ModuleRevisionPublished(moduleRevision.getPath());
+        ModuleRevisionPublishedEvent event = new ModuleRevisionPublishedEvent(moduleRevision.getPath());
         Map<String, Object> props = newHashMap();
         props.put(Event.class.getName(), event);
         Job job = jobManager.createJob(MODULE_POST_PUBLISH_EVENT)

--- a/src/main/java/com/redhat/pantheon/extension/ModulePostPublishExtension.java
+++ b/src/main/java/com/redhat/pantheon/extension/ModulePostPublishExtension.java
@@ -1,14 +1,14 @@
 package com.redhat.pantheon.extension;
 
-import com.redhat.pantheon.extension.events.ModuleRevisionPublished;
+import com.redhat.pantheon.extension.events.ModuleRevisionPublishedEvent;
 
 /**
- * Interface that processes {@link ModuleRevisionPublished} events. OSGI-declared components (i.e.
+ * Interface that processes {@link ModuleRevisionPublishedEvent} events. OSGI-declared components (i.e.
  * having the @{@link org.osgi.service.component.annotations.Component} annotation) which
  * implement this interface will be picked up by the matching {@link EventJobConsumer} and will
  * be invoked when such an event is fired.
  *
  * @author Carlos Munoz
  */
-public interface ModulePostPublishExtension extends EventProcessingExtension<ModuleRevisionPublished> {
+public interface ModulePostPublishExtension extends EventProcessingExtension<ModuleRevisionPublishedEvent> {
 }

--- a/src/main/java/com/redhat/pantheon/extension/ModulePostPublishExtension.java
+++ b/src/main/java/com/redhat/pantheon/extension/ModulePostPublishExtension.java
@@ -1,0 +1,14 @@
+package com.redhat.pantheon.extension;
+
+import com.redhat.pantheon.extension.events.ModuleRevisionPublished;
+
+/**
+ * Interface that processes {@link ModuleRevisionPublished} events. OSGI-declared components (i.e.
+ * having the @{@link org.osgi.service.component.annotations.Component} annotation) which
+ * implement this interface will be picked up by the matching {@link EventJobConsumer} and will
+ * be invoked when such an event is fired.
+ *
+ * @author Carlos Munoz
+ */
+public interface ModulePostPublishExtension extends EventProcessingExtension<ModuleRevisionPublished> {
+}

--- a/src/main/java/com/redhat/pantheon/extension/ModulePostPublishJobConsumer.java
+++ b/src/main/java/com/redhat/pantheon/extension/ModulePostPublishJobConsumer.java
@@ -1,0 +1,25 @@
+package com.redhat.pantheon.extension;
+
+import org.apache.sling.event.jobs.consumer.JobConsumer;
+import org.osgi.service.component.annotations.Component;
+
+import static com.redhat.pantheon.extension.Events.MODULE_POST_PUBLISH_EVENT;
+
+/**
+ * A consumer for Module post publish events.
+ * This consumer makes sure that the events are processed, and any possible errors
+ * are reported. It will call on all registered OSGI components under the {@link EventProcessingExtension}
+ * service interface and will report if there is a failure. If any extension fails its processing,
+ * no retries will be attempted. It is up to the extension developer to make sure their extensions are
+ * working properly.
+ */
+@Component(
+        service = JobConsumer.class,
+        property = JobConsumer.PROPERTY_TOPICS + "=" + MODULE_POST_PUBLISH_EVENT
+)
+public class ModulePostPublishJobConsumer extends EventJobConsumer<ModulePostPublishExtension> {
+
+    public ModulePostPublishJobConsumer() {
+        super(ModulePostPublishExtension.class);
+    }
+}

--- a/src/main/java/com/redhat/pantheon/extension/events/ModuleRevisionPublished.java
+++ b/src/main/java/com/redhat/pantheon/extension/events/ModuleRevisionPublished.java
@@ -1,0 +1,18 @@
+package com.redhat.pantheon.extension.events;
+
+import com.redhat.pantheon.extension.Event;
+
+import javax.annotation.Nonnull;
+
+public class ModuleRevisionPublished implements Event {
+
+    private final String moduleRevisionPath;
+
+    public ModuleRevisionPublished(@Nonnull String moduleRevisionPath) {
+        this.moduleRevisionPath = moduleRevisionPath;
+    }
+
+    public String getModuleRevisionPath() {
+        return moduleRevisionPath;
+    }
+}

--- a/src/main/java/com/redhat/pantheon/extension/events/ModuleRevisionPublishedEvent.java
+++ b/src/main/java/com/redhat/pantheon/extension/events/ModuleRevisionPublishedEvent.java
@@ -4,11 +4,16 @@ import com.redhat.pantheon.extension.Event;
 
 import javax.annotation.Nonnull;
 
-public class ModuleRevisionPublished implements Event {
+/**
+ * Event fired when a module revision has been published.
+ * Includes the module revision path so it can be re-fetched in the
+ * handlers if necessary.
+ */
+public class ModuleRevisionPublishedEvent implements Event {
 
     private final String moduleRevisionPath;
 
-    public ModuleRevisionPublished(@Nonnull String moduleRevisionPath) {
+    public ModuleRevisionPublishedEvent(@Nonnull String moduleRevisionPath) {
         this.moduleRevisionPath = moduleRevisionPath;
     }
 

--- a/src/main/java/com/redhat/pantheon/model/api/SlingResourceAdapterFactory.java
+++ b/src/main/java/com/redhat/pantheon/model/api/SlingResourceAdapterFactory.java
@@ -27,6 +27,7 @@ import static org.apache.sling.api.adapter.AdapterFactory.ADAPTER_CLASSES;
                 ADAPTER_CLASSES + "=com.redhat.pantheon.model.api.SlingResource",
                 ADAPTER_CLASSES + "=com.redhat.pantheon.model.api.FileResource",
                 ADAPTER_CLASSES + "=com.redhat.pantheon.model.module.Module",
+                ADAPTER_CLASSES + "=com.redhat.pantheon.model.module.ModuleRevision",
                 ADAPTER_CLASSES + "=com.redhat.pantheon.model.module.Content",
                 ADAPTER_CLASSES + "=com.redhat.pantheon.model.module.Metadata",
         }

--- a/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
@@ -1,6 +1,7 @@
 package com.redhat.pantheon.servlet.module;
 
 import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.extension.Events;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.Module.ModuleLocale;
 import com.redhat.pantheon.model.module.ModuleRevision;
@@ -10,7 +11,9 @@ import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostOperation;
 import org.apache.sling.servlets.post.PostResponse;
 import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletResponse;
@@ -28,6 +31,14 @@ import static com.redhat.pantheon.servlet.ServletUtils.paramValueAsLocale;
                 PostOperation.PROP_OPERATION_NAME + "=pant:release"
         })
 public class ReleaseDraftRevision extends AbstractPostOperation {
+
+    private Events events;
+
+    @Activate
+    public ReleaseDraftRevision(@Reference Events events) {
+        this.events = events;
+    }
+
     @Override
     protected void doRun(SlingHttpServletRequest request, PostResponse response, List<Modification> changes) throws RepositoryException {
         Locale locale = paramValueAsLocale(request, "locale", GlobalConfig.DEFAULT_MODULE_LOCALE);
@@ -35,8 +46,8 @@ public class ReleaseDraftRevision extends AbstractPostOperation {
         Module module = request.getResource().adaptTo(Module.class);
 
         // Get the draft revision, there should be one
-        Optional<ModuleRevision> draftRevision = module.getDraftRevision(locale);
-        if( !draftRevision.isPresent() ) {
+        Optional<ModuleRevision> revisionToRelease = module.getDraftRevision(locale);
+        if( !revisionToRelease.isPresent() ) {
             response.setStatus(HttpServletResponse.SC_PRECONDITION_FAILED,
                     "The module doesn't have a draft revision to be released");
         } else {
@@ -45,6 +56,9 @@ public class ReleaseDraftRevision extends AbstractPostOperation {
             moduleLocale.released.set( moduleLocale.draft.get() );
             moduleLocale.draft.set( null );
             changes.add(Modification.onModified(module.getPath()));
+
+            // call the extension point
+            events.fireModuleRevisionPublishedEvent(moduleLocale.released.getReference());
         }
     }
 }

--- a/src/test/java/com/redhat/pantheon/extension/EventJobConsumerTest.java
+++ b/src/test/java/com/redhat/pantheon/extension/EventJobConsumerTest.java
@@ -1,0 +1,85 @@
+package com.redhat.pantheon.extension;
+
+import org.apache.sling.event.jobs.Job;
+import org.apache.sling.event.jobs.consumer.JobConsumer.JobResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.InvalidSyntaxException;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class})
+class EventJobConsumerTest {
+
+    @Mock
+    Job job;
+
+    @Test
+    void process() throws Exception {
+        // Given
+        Event event = mock(Event.class, Answers.RETURNS_MOCKS);
+        EventProcessingExtension extension = mock(EventProcessingExtension.class);
+        lenient().when(job.getProperty(Event.class.getName(), Event.class)).thenReturn(event);
+        TestEventJobConsumer jobConsumer = new TestEventJobConsumer(extension);
+
+        // When
+        JobResult result = jobConsumer.process(job);
+
+        // Then
+        assertEquals(JobResult.OK, result);
+        verify(extension, times(1)).processEvent(eq(event));
+    }
+
+    @Test
+    void processExtensionWhichThrowsException() throws Exception {
+        // Given
+        Event event = mock(Event.class, Answers.RETURNS_MOCKS);
+        EventProcessingExtension extension1 = mock(EventProcessingExtension.class);
+        EventProcessingExtension extension2 = mock(EventProcessingExtension.class);
+        lenient().when(job.getProperty(Event.class.getName(), Event.class)).thenReturn(event);
+        lenient().doThrow(new Exception()).when(extension2).processEvent(eq(event));
+        TestEventJobConsumer jobConsumer = new TestEventJobConsumer(extension1, extension2);
+
+        // When
+        JobResult result = jobConsumer.process(job);
+
+        // Then
+        assertEquals(JobResult.OK, result);
+        verify(extension1, times(1)).processEvent(eq(event));
+        verify(extension2, times(1)).processEvent(eq(event));
+    }
+
+    @Test
+    void processWithNoEvent() {
+        // Given
+        TestEventJobConsumer jobConsumer = new TestEventJobConsumer();
+
+        // When
+        JobResult result = jobConsumer.process(job);
+
+        // Then
+        assertEquals(JobResult.CANCEL, result);
+    }
+
+    private static class TestEventJobConsumer extends EventJobConsumer<EventProcessingExtension> {
+
+        private final EventProcessingExtension[] extensions;
+
+        public TestEventJobConsumer(EventProcessingExtension ... extensions) {
+            super(EventProcessingExtension.class);
+            this.extensions = extensions;
+        }
+
+        @Override
+        protected Collection<EventProcessingExtension> getExtensions() {
+            return Arrays.asList(extensions);
+        }
+    }
+}

--- a/src/test/java/com/redhat/pantheon/extension/EventJobConsumerTest.java
+++ b/src/test/java/com/redhat/pantheon/extension/EventJobConsumerTest.java
@@ -44,6 +44,7 @@ class EventJobConsumerTest {
         EventProcessingExtension extension1 = mock(EventProcessingExtension.class);
         EventProcessingExtension extension2 = mock(EventProcessingExtension.class);
         lenient().when(job.getProperty(Event.class.getName(), Event.class)).thenReturn(event);
+        lenient().doThrow(new Exception()).when(extension1).processEvent(eq(event));
         lenient().doThrow(new Exception()).when(extension2).processEvent(eq(event));
         TestEventJobConsumer jobConsumer = new TestEventJobConsumer(extension1, extension2);
 

--- a/src/test/java/com/redhat/pantheon/extension/EventsTest.java
+++ b/src/test/java/com/redhat/pantheon/extension/EventsTest.java
@@ -1,18 +1,16 @@
 package com.redhat.pantheon.extension;
 
 import com.redhat.pantheon.model.module.ModuleRevision;
+import org.apache.sling.event.jobs.JobBuilder;
 import org.apache.sling.event.jobs.JobManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class})
 class EventsTest {
@@ -27,11 +25,16 @@ class EventsTest {
     void fireModuleRevisionPublishedEvent() {
         // Given
         Events events = new Events(jobManager);
+        JobBuilder jobBuilder = mock(JobBuilder.class, RETURNS_MOCKS);
+        lenient().when(jobManager.createJob(anyString())).thenReturn(jobBuilder);
+        lenient().when(jobBuilder.properties(anyMap())).thenReturn(jobBuilder);
 
         // When
         events.fireModuleRevisionPublishedEvent(moduleRevision);
 
         // Then
+        verify(jobBuilder, times(1)).properties(anyMap());
+        verify(jobBuilder, times(1)).add();
         verify(jobManager, times(1)).createJob(eq(Events.MODULE_POST_PUBLISH_EVENT));
     }
 }

--- a/src/test/java/com/redhat/pantheon/extension/EventsTest.java
+++ b/src/test/java/com/redhat/pantheon/extension/EventsTest.java
@@ -1,0 +1,37 @@
+package com.redhat.pantheon.extension;
+
+import com.redhat.pantheon.model.module.ModuleRevision;
+import org.apache.sling.event.jobs.JobManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class})
+class EventsTest {
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    JobManager jobManager;
+
+    @Mock
+    ModuleRevision moduleRevision;
+
+    @Test
+    void fireModuleRevisionPublishedEvent() {
+        // Given
+        Events events = new Events(jobManager);
+
+        // When
+        events.fireModuleRevisionPublishedEvent(moduleRevision);
+
+        // Then
+        verify(jobManager, times(1)).createJob(eq(Events.MODULE_POST_PUBLISH_EVENT));
+    }
+}

--- a/src/test/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevisionTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevisionTest.java
@@ -1,7 +1,7 @@
 package com.redhat.pantheon.servlet.module;
 
+import com.redhat.pantheon.extension.Events;
 import com.redhat.pantheon.model.module.Module;
-import com.redhat.pantheon.util.TestUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.servlets.post.HtmlResponse;
 import org.apache.sling.servlets.post.Modification;
@@ -9,7 +9,6 @@ import org.apache.sling.servlets.post.ModificationType;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +19,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith({SlingContextExtension.class})
 class ReleaseDraftRevisionTest {
@@ -41,10 +41,11 @@ class ReleaseDraftRevisionTest {
         slingContext.resourceResolver().getResource("/module/en_US").adaptTo(ModifiableValueMap.class)
                 .put("draft", slingContext.resourceResolver().getResource("/module/en_US/v0").getValueMap().get("jcr:uuid"));
         registerMockAdapter(Module.class, slingContext);
+        Events events = mock(Events.class);
         HtmlResponse postResponse = new HtmlResponse();
         List<Modification> changes = newArrayList();
         slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
-        ReleaseDraftRevision operation = new ReleaseDraftRevision();
+        ReleaseDraftRevision operation = new ReleaseDraftRevision(events);
 
         // When
         operation.doRun(slingContext.request(), postResponse, changes);
@@ -69,7 +70,7 @@ class ReleaseDraftRevisionTest {
         HtmlResponse postResponse = new HtmlResponse();
         List<Modification> changes = newArrayList();
         slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
-        ReleaseDraftRevision operation = new ReleaseDraftRevision();
+        ReleaseDraftRevision operation = new ReleaseDraftRevision(null);
 
         // When
         operation.doRun(slingContext.request(), postResponse, changes);


### PR DESCRIPTION
This enables the possibility to add extension points to the system in asynchronous fashion. There are two main components in the mechanism:

The `Events` class serves as the single place where to fire an event. Events are hardcoded into methods and other system components should use this class to fire events when appropriate. On the receiving end, there are `JobConsumer`s, which receive the events and process them. Events are placed in queues and JobConsumers are created for each one of these queues. There should be as many queues as JobConsumers are created. It is possible to create a single queue to process all events if desired.

The last layer is the `EventProcessingExtension`. This is an interface that should be implemented to process individual types of events. Aside from implementing this interface, extensions should also be declared as an OSGI component; this allows the system to pick them up from different bundles and process them. Each identified extension will be given the event to be processed. Failure to process the event will not stop other extensions from being invoked, and similarly will not revert the main operation which triggered the event.

The first (and only so far) event being fired is a post-publish event for a module revision. There are no extensions so far registered, but one possible extension would be to send the published module revision to a search index.