### PR TITLE
CCS-2975: asciidoc metadata

### DIFF
--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -23,6 +23,12 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  * value in the resource.
  * </p>
  *
+ * <p>
+ * For more information about how to interpret and extract data from the asciidoctor
+ * AST, see:
+ * https://github.com/asciidoctor/asciidoctorj/blob/asciidoctorj-1.6.0/docs/integrator-guide.adoc#understanding-the-ast-classes
+ * </p>
+ *
  * @author Carlos Munoz
  */
 public class MetadataExtractorTreeProcessor extends Treeprocessor {
@@ -37,9 +43,14 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
     public Document process(Document document) {
         extractDocTitle(document);
         extractAbstract(document);
+        extractHeadline(document);
         return document;
     }
 
+    /**
+     * Extracts the document title from an asciidoc document
+     * @param document
+     */
     private void extractDocTitle(Document document) {
         String docTitle = document.getDoctitle();
         if(!isNullOrEmpty(docTitle)) {
@@ -47,6 +58,11 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
         }
     }
 
+    /**
+     * Extracts the document's abstract from an asciidoc document.
+     * The abstract is assumed to be the first paragraph of text in the document.
+     * @param document
+     */
     private void extractAbstract(Document document) {
         // Abstract is the first paragraph
         if(document.getBlocks().size() > 0) {
@@ -55,8 +71,28 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
                 String abstractContent = firstBlock.getContent().toString();
                 if (!isNullOrEmpty(abstractContent)) {
                     metadata.mAbstract.set(abstractContent);
+                    return;
                 }
             }
         }
+        // If no abstract is detected, reset it
+        metadata.mAbstract.set(null);
+    }
+
+    /**
+     * Extracts the document's headline from an asciidoc document.
+     * The headline is the first second-level header in the document (if one is present).
+     * @param document
+     */
+    private void extractHeadline(Document document) {
+        // Get the first section (that's where a subtitle will be)
+        for (StructuralNode block : document.getBlocks()) {
+            if (block.getContext().equals("section") && block.getLevel() == 1) {
+                metadata.headline.set(block.getTitle());
+                return;
+            }
+        }
+        // if no headline is detected, reset it
+        metadata.headline.set(null);
     }
 }

--- a/src/main/java/com/redhat/pantheon/model/api/EnumField.java
+++ b/src/main/java/com/redhat/pantheon/model/api/EnumField.java
@@ -1,0 +1,26 @@
+package com.redhat.pantheon.model.api;
+
+import javax.annotation.Nullable;
+
+/**
+ * An enumeration typed field. Only allows values of the given enumeration
+ * and will store them in the JCR tree as a string.
+ *
+ * @author Carlos Munoz
+ */
+public class EnumField<T extends Enum> extends Field<T> {
+
+    EnumField(String name, Class<T> type, SlingResource owner) {
+        super(name, type, owner);
+    }
+
+    @Override
+    public void set(@Nullable T value) {
+        new Field<>(name, String.class, owner).set( value == null ? null : value.name() );
+    }
+
+    @Override
+    public T get() {
+        return (T)Enum.valueOf(type, new Field<>(name, String.class, owner).get());
+    }
+}

--- a/src/main/java/com/redhat/pantheon/model/api/Field.java
+++ b/src/main/java/com/redhat/pantheon/model/api/Field.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.model.api;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 
+import javax.annotation.Nullable;
 import javax.jcr.RepositoryException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -56,11 +57,18 @@ public class Field<T> implements Supplier<T>, Consumer<T> {
     }
 
     /**
-     * Sets the value on the jcr field of the underlying resource
+     * Sets the value on the jcr field of the underlying resource.
+     * Setting a field to null effectively removes the field from the resource.
      * @param value
      */
-    public void set(T value) {
-        owner.adaptTo(ModifiableValueMap.class).put(name, value);
+    public void set(@Nullable T value) {
+        ModifiableValueMap mvm = owner.adaptTo(ModifiableValueMap.class);
+        if(value == null) {
+            mvm.remove(name);
+        }
+        else {
+            mvm.put(name, value);
+        }
     }
 
     /**

--- a/src/main/java/com/redhat/pantheon/model/api/SlingResource.java
+++ b/src/main/java/com/redhat/pantheon/model/api/SlingResource.java
@@ -155,6 +155,17 @@ public class SlingResource implements Resource {
         return new Field<>(name, Calendar.class, this);
     }
 
+    /**
+     * Creates new Enumeration-typed field definition for this resource.
+     * @param name Field name
+     * @param enumType The type of enumeration the new field will contain
+     * @param <T>
+     * @return A new Enumeration-typed field definition for this SlingResource.
+     */
+    protected <T extends Enum> Field<T> enumField(String name, Class<T> enumType) {
+        return new EnumField<>(name, enumType, this);
+    }
+
     protected <T extends SlingResource> ReferenceField<T> referenceField(String name, Class<T> refType) {
         return new ReferenceField<>(name, refType, this);
     }

--- a/src/main/java/com/redhat/pantheon/model/module/Metadata.java
+++ b/src/main/java/com/redhat/pantheon/model/module/Metadata.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.model.module;
 
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.SlingResource;
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.Resource;
 
 import java.util.Calendar;
@@ -17,11 +18,19 @@ public class Metadata extends SlingResource {
 
     public final Field<String> mAbstract = stringField("pant:abstract");
 
+    public final Field<String> headline = stringField("pant:headline");
+
     public final Field<String> description = stringField("jcr:description");
 
     public final Field<Calendar> created = dateField("jcr:created");
 
     public final Field<String> createdBy = stringField("jcr:createdBy");
+
+    public final Field<ModuleType> moduleType = enumField("pant:moduleType", ModuleType.class);
+
+    public final Field<Calendar> datePublished = dateField("pant:datePublished");
+
+    public final Field<Calendar> dateModified = dateField(JcrConstants.JCR_LASTMODIFIED);
 
     public final Field<String> primaryType = stringField("jcr:primaryType");
 

--- a/src/main/java/com/redhat/pantheon/model/module/ModuleType.java
+++ b/src/main/java/com/redhat/pantheon/model/module/ModuleType.java
@@ -1,0 +1,12 @@
+package com.redhat.pantheon.model.module;
+
+/**
+ * An enumeration declaring valid module types.
+ *
+ * @author Carlos Munoz
+ */
+public enum ModuleType {
+    CONCEPT,
+    PROCEDURE,
+    REFERENCE
+}

--- a/src/main/java/com/redhat/pantheon/servlet/ModuleRevisionUpload.java
+++ b/src/main/java/com/redhat/pantheon/servlet/ModuleRevisionUpload.java
@@ -7,6 +7,7 @@ import com.redhat.pantheon.model.api.SlingResourceUtil;
 import com.redhat.pantheon.model.module.Metadata;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleRevision;
+import com.redhat.pantheon.model.module.ModuleType;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -23,10 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Post operation to add a new Module revision to the system.
@@ -114,6 +112,8 @@ public class ModuleRevisionUpload extends AbstractPostOperation {
                     .metadata.getOrCreate();
             metadata.title.set(moduleName);
             metadata.description.set(description);
+            metadata.dateModified.set(Calendar.getInstance());
+            metadata.moduleType.set( determineModuleType(module) );
 
             asciidoctorService.extractMetadata(jcrContent, metadata);
 
@@ -126,6 +126,28 @@ public class ModuleRevisionUpload extends AbstractPostOperation {
             }
         } catch (Exception e) {
             throw new RepositoryException("Error uploading a module revision", e);
+        }
+    }
+
+    /**
+     * Determines the module type from the uploaded module revision
+     * @param module The uploaded module
+     * @return A module type for the module revision, or null if one cannot be determined.
+     */
+    private static ModuleType determineModuleType(Module module) {
+        String fileName = module.getName();
+
+        if( fileName.startsWith("proc_") ) {
+            return ModuleType.PROCEDURE;
+        }
+        else if( fileName.startsWith("con_") ) {
+            return ModuleType.CONCEPT;
+        }
+        else if( fileName.startsWith("ref_") ) {
+            return ModuleType.REFERENCE;
+        }
+        else {
+            return null;
         }
     }
 }

--- a/src/main/java/com/redhat/pantheon/servlet/ModuleRevisionUpload.java
+++ b/src/main/java/com/redhat/pantheon/servlet/ModuleRevisionUpload.java
@@ -24,7 +24,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
-import java.util.*;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Post operation to add a new Module revision to the system.

--- a/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -55,6 +56,10 @@ public class ReleaseDraftRevision extends AbstractPostOperation {
             ModuleLocale moduleLocale = module.getModuleLocale(locale);
             moduleLocale.released.set( moduleLocale.draft.get() );
             moduleLocale.draft.set( null );
+            // set the published date on the draft revision
+            draftRevision.get()
+                    .metadata.getOrCreate()
+                    .datePublished.set(Calendar.getInstance());
             changes.add(Modification.onModified(module.getPath()));
 
             // call the extension point

--- a/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
@@ -56,8 +56,8 @@ public class ReleaseDraftRevision extends AbstractPostOperation {
             ModuleLocale moduleLocale = module.getModuleLocale(locale);
             moduleLocale.released.set( moduleLocale.draft.get() );
             moduleLocale.draft.set( null );
-            // set the published date on the draft revision
-            draftRevision.get()
+            // set the published date on the released revision
+            revisionToRelease.get()
                     .metadata.getOrCreate()
                     .datePublished.set(Calendar.getInstance());
             changes.add(Modification.onModified(module.getPath()));

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
@@ -11,7 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 class MetadataExtractorTreeProcessorTest {

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
@@ -11,8 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 class MetadataExtractorTreeProcessorTest {
@@ -23,12 +22,12 @@ class MetadataExtractorTreeProcessorTest {
     void extractMetadata() {
         // Given
         slingContext.build()
-                .resource("/content/module1/locales/en_US/metadata/released")
+                .resource("/content/module1/locales/en_US/1/metadata")
                 .commit();
         Metadata metadata =
                 new Metadata(
                     slingContext.resourceResolver().getResource(
-                            "/content/module1/locales/en_US/metadata/released"));
+                            "/content/module1/locales/en_US/1/metadata"));
         MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         asciidoctor.javaExtensionRegistry().treeprocessor(extension);
@@ -41,20 +40,20 @@ class MetadataExtractorTreeProcessorTest {
         asciidoctor.load(adocContent, new HashMap<>());
 
         // Then
-        assertEquals("A title for content", metadata.getValueMap().get("jcr:title"));
+        assertEquals("A title for content", metadata.title.get());
         assertEquals("This is the first paragraph which serves as abstract for a module",
-                metadata.getValueMap().get("pant:abstract"));
+                metadata.mAbstract.get());
     }
 
     @Test
     void extractMetadataAbstractNotPresent() {
         // Given
         slingContext.build()
-                .resource("/content/module1/locales/en_US/metadata/released")
+                .resource("/content/module1/locales/en_US/1/metadata")
                 .commit();
         Metadata metadata =
                 new Metadata(
-                        slingContext.resourceResolver().getResource("/content/module1/locales/en_US/metadata/released"));
+                        slingContext.resourceResolver().getResource("/content/module1/locales/en_US/1/metadata"));
         Resource module = slingContext.resourceResolver().getResource("/content/module1");
         MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
@@ -65,6 +64,57 @@ class MetadataExtractorTreeProcessorTest {
         asciidoctor.load(adocContent, new HashMap<>());
 
         // Then
-        assertFalse(module.getValueMap().containsKey("pant:abstract"));
+        assertNull(metadata.mAbstract.get());
+    }
+
+    @Test
+    void extractHeadline() {
+        // Given
+        slingContext.build()
+                .resource("/content/module1/locales/en_US/1/metadata")
+                .commit();
+        Metadata metadata =
+                new Metadata(
+                        slingContext.resourceResolver().getResource(
+                                "/content/module1/locales/en_US/1/metadata"));
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent = "= A title for content" +
+                "\n" +
+                "\n" +
+                "== Headline" +
+                "\n" +
+                "\n" +
+                "This is the first section.";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertEquals("Headline", metadata.headline.get());
+    }
+
+    @Test
+    void extractHeadlineNotPresent() {
+        // Given
+        slingContext.build()
+                .resource("/content/module1/locales/en_US/1/metadata")
+                .commit();
+        Metadata metadata =
+                new Metadata(
+                        slingContext.resourceResolver().getResource(
+                                "/content/module1/locales/en_US/1/metadata"));
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent = "= A title for content" +
+                "\n";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertNull(metadata.headline.get());
     }
 }

--- a/src/test/java/com/redhat/pantheon/model/api/SlingResourceTest.java
+++ b/src/test/java/com/redhat/pantheon/model/api/SlingResourceTest.java
@@ -28,7 +28,8 @@ class SlingResourceTest {
                         "jcr:date", Calendar.getInstance(),
                         "jcr:number", "10",
                         "jcr:boolean", false,
-                        "jcr:stringArray", stringArrayValue)
+                        "jcr:stringArray", stringArrayValue,
+                        "jcr:multiValue", MultiValue.VALUE_1)
                 .commit();
 
         TestResource model = new TestResource(slingContext.resourceResolver().getResource("/content/module1"));
@@ -39,6 +40,7 @@ class SlingResourceTest {
         assertEquals(false, model.BOOLEAN.get());
         assertNotNull(model.DATE.get());
         assertEquals(stringArrayValue, model.STRINGARRAY.get());
+        assertEquals(MultiValue.VALUE_1, model.ENUM.get());
     }
 
     @Test
@@ -365,6 +367,7 @@ class SlingResourceTest {
         public final Field<Boolean> BOOLEAN = field("jcr:boolean", Boolean.class);
         public final Field<String[]> STRINGARRAY = field("jcr:stringArray", String[].class);
         public final Field<String> STRING_WITH_DEFAULT = stringField("stringWithDefault").defaultValue("default");
+        public final Field<MultiValue> ENUM = enumField("jcr:multiValue", MultiValue.class);
 
         public final Field<String> GRANDCHILD_NAME = stringField("child/grandchild/jcr:name");
 
@@ -392,5 +395,10 @@ class SlingResourceTest {
         public Grandchild(Resource resource) {
             super(resource);
         }
+    }
+
+    public static enum MultiValue {
+        VALUE_1,
+        VALUE_2
     }
 }

--- a/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/ModuleRevisionUploadTest.java
@@ -3,6 +3,7 @@ package com.redhat.pantheon.servlet;
 import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleRevision;
+import com.redhat.pantheon.model.module.ModuleType;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.NonExistingResource;
@@ -51,18 +52,23 @@ class ModuleRevisionUploadTest {
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
         slingContext.request().setParameterMap(params);
-        slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/module"));
+        slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/proc_module"));
 
         // when
         upload.doRun(slingContext.request(), new HtmlResponse(), null);
 
         // Then
-        assertNotNull(slingContext.resourceResolver().getResource("/new/module/es_ES/1/content"));
-        assertNotNull(slingContext.resourceResolver().getResource("/new/module/es_ES/1/metadata"));
-        assertNotNull(slingContext.resourceResolver().getResource("/new/module/es_ES/draft"));
-        assertNull(slingContext.resourceResolver().getResource("/new/module/es_ES/released"));
+        assertNotNull(slingContext.resourceResolver().getResource("/new/proc_module/es_ES/1/content"));
+        assertNotNull(slingContext.resourceResolver().getResource("/new/proc_module/es_ES/1/metadata"));
+        assertNotNull(slingContext.resourceResolver().getResource("/new/proc_module/es_ES/draft"));
+        assertNull(slingContext.resourceResolver().getResource("/new/proc_module/es_ES/released"));
 
-        Module module = new Module(slingContext.resourceResolver().getResource("/new/module"));
+        Module module = new Module(slingContext.resourceResolver().getResource("/new/proc_module"));
+        assertEquals(ModuleType.PROCEDURE,
+                module.getModuleLocale(LocaleUtils.toLocale("es_ES"))
+                        .getRevision("1")
+                        .metadata.get()
+                        .moduleType.get());
         assertEquals("This is the adoc content",
                 module.getDraftContent(LocaleUtils.toLocale("es_ES")).get().asciidocContent.get()
         );

--- a/src/test/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevisionTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevisionTest.java
@@ -56,6 +56,7 @@ class ReleaseDraftRevisionTest {
         assertEquals("/module", changes.get(0).getSource());
         assertEquals(HttpServletResponse.SC_OK, postResponse.getStatusCode());
         assertNotNull(slingContext.resourceResolver().getResource("/module/en_US/released"));
+        assertNotNull(slingContext.resourceResolver().getResource("/module/en_US/1/metadata/pant:datePublished"));
     }
 
     @Test


### PR DESCRIPTION
Enables the extraction of additional pieces of metadata, most of them coming from the asciidoc content itself:

- Headline: Headline is the first second-level header in the asciidoc content (if present)
- Module type: A naming convention on the module file.
- Date published

Already present:
- Title
- Abstract: The first paragraph of text in the module.