### PR TITLE
Set server only if PANTHEON_SERVER ENVVAR is not set.

### DIFF
--- a/tools/git2pantheon/Dockerfile
+++ b/tools/git2pantheon/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:30 AS builder
 #Force the use of the mirror: http://download-ib01.fedoraproject.org/pub
 RUN sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-updates.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-updates.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-updates.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-updates-modular.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-updates-modular.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-updates-modular.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-modular.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-modular.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-modular.repo
-RUN dnf -y update && dnf -y install wget golang && dnf clean all
+RUN dnf -y install wget golang && dnf clean all
 RUN mkdir -p /go && chmod -R 777 /go
 ENV GOPATH=/go
 WORKDIR /go

--- a/tools/git2pantheon/Dockerfile
+++ b/tools/git2pantheon/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:30 AS builder
 #Force the use of the mirror: http://download-ib01.fedoraproject.org/pub
 RUN sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-updates.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-updates.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-updates.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-updates-modular.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-updates-modular.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-updates-modular.repo && sed -e '/metalink/s/^/#/g' -i /etc/yum.repos.d/fedora-modular.repo && sed -i '/baseurl/s/^#//g' /etc/yum.repos.d/fedora-modular.repo && sed -i 's/download/download-ib01/g' /etc/yum.repos.d/fedora-modular.repo
-RUN dnf -y update && dnf -y install golang && dnf clean all
+RUN dnf -y update && dnf -y install wget golang && dnf clean all
 RUN mkdir -p /go && chmod -R 777 /go
 ENV GOPATH=/go
 WORKDIR /go
@@ -10,10 +10,12 @@ ADD . /go/app/
 WORKDIR /go/app 
 RUN go get gopkg.in/src-d/go-git.v4
 RUN go build -o main .
+RUN wget https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py
 
 #Use RHEL 8 Universal Base Image with python-3.6 support as runtime.
 FROM registry.access.redhat.com/ubi8/python-36
 RUN pip install requests pyyaml
 COPY --from=builder /go/app/main .
+COPY --from=builder /go/app/pantheon.py .
 CMD ["./main"]
 EXPOSE 9666/tcp

--- a/tools/git2pantheon/git_uploader.go
+++ b/tools/git2pantheon/git_uploader.go
@@ -32,17 +32,19 @@ func gitClone(repository string, branch string, directory string) {
 }
 
 func getUploader() {
-	const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"
-	args := []string{"-o", "./pantheon.py", uploader_url}
-	cmd := exec.Command("curl", args...)
-	out, err := cmd.Output()
-	if err != nil {
-		//Uploader call still on the same gorutine.
-		log.Print(err)
+	if _, err := os.Stat("./pantheon.py"); os.IsNotExist(err) {
+		const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"
+		args := []string{"-o", "./pantheon.py", uploader_url}
+		cmd := exec.Command("curl", args...)
+		out, err := cmd.Output()
+		if err != nil {
+			//Uploader call still on the same gorutine.
+			log.Print(err)
+		}
+		log.Print("Successfully downloaded the uploader." + string(out))
 	}
-	log.Print("Successfully downloaded the uploader." + string(out))
 	log.Print("Setting uploader executable permissions.")
-	err = os.Chmod("./pantheon.py", 0755)
+	os.Chmod("./pantheon.py", 0755)
 }
 
 func push2Pantheon(directory string) {

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -302,7 +302,11 @@ def get_unspecified_files(directory, processed_files, follow_links=True):
     return unspecified_files
 
 
-server = resolveOption(args.server, 'server', DEFAULT_SERVER)
+if "PANTHEON2_SERVER" in os.environ:
+    server = os.environ["PANTHEON2_SERVER"]
+else:
+    server = resolveOption(args.server, 'server', DEFAULT_SERVER)
+
 repository = resolveOption(args.repository, 'repository', DEFAULT_REPOSITORY)
 links = resolveOption(args.links, 'followlinks', DEFAULT_LINKS)
 mode = 'sandbox' if args.sandbox else 'repository'

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -15,7 +15,10 @@ import glob
 from pathlib import PurePath
 
 DEFAULT_SERVER = 'http://localhost:8080'
-DEFAULT_REPOSITORY = getpass.getuser()
+if "PANTHEON_SERVER" in os.environ:
+    DEFAULT_REPOSITORY = 'gitImport'
+else:
+    DEFAULT_REPOSITORY = getpass.getuser()
 DEFAULT_USER = 'demo'
 DEFAULT_PASSWORD = base64.b64decode(b'ZGVtbw==').decode()
 DEFAULT_LINKS = False
@@ -302,8 +305,8 @@ def get_unspecified_files(directory, processed_files, follow_links=True):
     return unspecified_files
 
 
-if "PANTHEON2_SERVER" in os.environ:
-    server = os.environ["PANTHEON2_SERVER"]
+if "PANTHEON_SERVER" in os.environ:
+    server = os.environ["PANTHEON_SERVER"]
 else:
     server = resolveOption(args.server, 'server', DEFAULT_SERVER)
 


### PR DESCRIPTION
Introduce an Environment variable that will supersede user configuration. This is intended to be used on Openshift and automated deployments where git2pantheon calls the uploader. This will ensure that git2pantheon and the uploader talk to the intended environment and will disregard the pantheon2.yml server configuration that an user might be using to test locally.

Proof that the code works:
Var not set:
```
$ python3 uploader/pantheon.py push -d ~/Development/adocs/ 
Could not find a valid config file(pantheon2.yml) in this directory; all files will be treated as resource uploads.
server http://localhost:8080 is not reachable
```
I set the variable:
```
$ export PANTHEON2_SERVER=coolbeans.redhat.com
```

Result with the variable set:
```
$ python3 uploader/pantheon.py push -d ~/Development/adocs/ 
Could not find a valid config file(pantheon2.yml) in this directory; all files will be treated as resource uploads.
server coolbeans.redhat.com is not reachable
```