### PR TITLE
upgrade the asciidoctorj version to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.6.2</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorLifecycle.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorLifecycle.java
@@ -3,6 +3,7 @@ package com.redhat.pantheon.asciidoctor;
 import com.redhat.pantheon.conf.GlobalConfig;
 import com.redhat.pantheon.util.pool.PooledObjectLifecycle;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.jruby.internal.JRubyAsciidoctor;
 
 /**
  * Implementation of the pool lifecycle for {@link Asciidoctor} objects. These objects
@@ -20,7 +21,7 @@ class AsciidoctorLifecycle implements PooledObjectLifecycle<Asciidoctor> {
 
     @Override
     public Asciidoctor createInstance() {
-        return Asciidoctor.Factory.create(globalConfig.getGemPaths());
+        return JRubyAsciidoctor.Factory.create(globalConfig.getGemPaths());
     }
 
     @Override


### PR DESCRIPTION
This also upgrades the asciidoctor version to 2.0

The API changed a bit, and now the code has to explicitly refer to the `JRubyAsciidoctor` implementation (which is the same one it has been using all along) in order to run in the OSGI environment. There might be a better way to do it, but in the short term this change upgrades the system to the latest asciidoctor and asciidoctorj.