### PR TITLE
CCS-2965: add an action for unpublishing modules

### DIFF
--- a/src/main/java/com/redhat/pantheon/servlet/module/UnpublishRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/UnpublishRevision.java
@@ -1,0 +1,84 @@
+package com.redhat.pantheon.servlet.module;
+
+import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.extension.Events;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.ModuleRevision;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.servlets.post.AbstractPostOperation;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.PostOperation;
+import org.apache.sling.servlets.post.PostResponse;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.google.common.collect.Streams.stream;
+import static com.redhat.pantheon.servlet.ServletUtils.paramValueAsLocale;
+import static com.redhat.pantheon.util.function.FunctionalUtils.toLastElement;
+
+/**
+ * API action which unpublishes the latest released revision for a module, if there is one.
+ * This means the "released" pointer is set to null, and the revision should no longer be
+ * accessible through the rendering API.
+ *
+ * @author Carlos Munoz
+ */
+@Component(
+        service = PostOperation.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=Unpublishes the latest released revision of a module",
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team",
+                PostOperation.PROP_OPERATION_NAME + "=pant:unpublish"
+        })
+public class UnpublishRevision extends AbstractPostOperation {
+
+    private Events events;
+
+    @Activate
+    public UnpublishRevision(@Reference Events events) {
+        this.events = events;
+    }
+
+    @Override
+    protected void doRun(SlingHttpServletRequest request, PostResponse response, List<Modification> changes) throws RepositoryException {
+        Locale locale = paramValueAsLocale(request, "locale", GlobalConfig.DEFAULT_MODULE_LOCALE);
+
+        Module module = request.getResource().adaptTo(Module.class);
+
+        // Get the released revision, there should be one
+        Optional<ModuleRevision> revisionToUnpublish = module.getReleasedRevision(locale);
+        if( !revisionToUnpublish.isPresent() ) {
+            response.setStatus(HttpServletResponse.SC_PRECONDITION_FAILED,
+                    "The module is not released (published)");
+        } else {
+            // Released revision is emptied out
+            Module.ModuleLocale moduleLocale = module.getModuleLocale(locale);
+            moduleLocale.released.set( null );
+
+            // if there is no draft version, set the latest one as draft
+            if( !module.getDraftRevision(locale).isPresent() ) {
+                Optional<Resource> latestRev = stream(moduleLocale.getChildren())
+                        .reduce(toLastElement());
+                latestRev.ifPresent(resource -> {
+                    moduleLocale.draft.set(
+                            resource.adaptTo(ModuleRevision.class)
+                                    .uuid.get());
+                });
+            }
+
+            changes.add(Modification.onModified(module.getPath()));
+
+            // TODO call an extension point similar to ReleaseDraftRevision
+            // events.fireModuleRevisionUnpublishedEvent(...);
+        }
+    }
+}

--- a/src/main/java/com/redhat/pantheon/servlet/module/UnpublishRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/UnpublishRevision.java
@@ -62,17 +62,13 @@ public class UnpublishRevision extends AbstractPostOperation {
         } else {
             // Released revision is emptied out
             Module.ModuleLocale moduleLocale = module.getModuleLocale(locale);
+            String unpublishedRevId = moduleLocale.released.get();
             moduleLocale.released.set( null );
 
-            // if there is no draft version, set the latest one as draft
-            if( !module.getDraftRevision(locale).isPresent() ) {
-                Optional<Resource> latestRev = stream(moduleLocale.getChildren())
-                        .reduce(toLastElement());
-                latestRev.ifPresent(resource -> {
-                    moduleLocale.draft.set(
-                            resource.adaptTo(ModuleRevision.class)
-                                    .uuid.get());
-                });
+            // if there is no draft version, set the recently unpublished one as draft
+            // it is guaranteed to be the latest one
+            if (!module.getDraftRevision(locale).isPresent()) {
+                moduleLocale.draft.set(unpublishedRevId);
             }
 
             changes.add(Modification.onModified(module.getPath()));

--- a/src/test/java/com/redhat/pantheon/servlet/module/UnpublishRevisionTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/module/UnpublishRevisionTest.java
@@ -1,0 +1,86 @@
+package com.redhat.pantheon.servlet.module;
+
+import com.redhat.pantheon.extension.Events;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.ModuleRevision;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.servlets.post.HtmlResponse;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.ModificationType;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith({SlingContextExtension.class})
+class UnpublishRevisionTest {
+
+    SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Test
+    void doRun() throws Exception {
+        // Given
+        slingContext.create()
+                .resource("/module/en_US/1",
+                        "jcr:primaryType", "pant:moduleRevision");
+        slingContext.create()
+                .resource("/module/en_US/1/metadata",
+                        "jcr:title", "A published title");
+        slingContext.create()
+                .resource("/module/en_US/1/content/asciidoc/jcr:content",
+                        "jcr:data", "Released content");
+        slingContext.resourceResolver().getResource("/module/en_US").adaptTo(ModifiableValueMap.class)
+                .put("released", slingContext.resourceResolver().getResource("/module/en_US/1").getValueMap().get("jcr:uuid"));
+        registerMockAdapter(Module.class, slingContext);
+        registerMockAdapter(ModuleRevision.class, slingContext);
+        Events events = mock(Events.class);
+        HtmlResponse postResponse = new HtmlResponse();
+        List<Modification> changes = newArrayList();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
+        UnpublishRevision operation = new UnpublishRevision(events);
+
+        // When
+        operation.doRun(slingContext.request(), postResponse, changes);
+
+        // Then
+        assertEquals(1, changes.size());
+        assertEquals(ModificationType.MODIFY, changes.get(0).getType());
+        assertEquals("/module", changes.get(0).getSource());
+        assertEquals(HttpServletResponse.SC_OK, postResponse.getStatusCode());
+        assertNull(slingContext.resourceResolver().getResource("/module/en_US/released"));
+        assertNotNull(slingContext.resourceResolver().getResource("/module/en_US/draft"));
+
+    }
+
+    @Test
+    @DisplayName("doRun for module with no released revision")
+    void doRunNoDraftRevision() throws Exception {
+        // Given
+        slingContext.build()
+                .resource("/module/locales/en_US/released/metadata")
+                .resource("/module/locales/en_US/released/content/asciidoc/jcr:content")
+                .commit();
+        registerMockAdapter(Module.class, slingContext);
+        HtmlResponse postResponse = new HtmlResponse();
+        List<Modification> changes = newArrayList();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
+        UnpublishRevision operation = new UnpublishRevision(null);
+
+        // When
+        operation.doRun(slingContext.request(), postResponse, changes);
+
+        // Then
+        assertTrue(changes.size() == 0);
+        assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, postResponse.getStatusCode());
+    }
+}


### PR DESCRIPTION
This pull request sets the stage for module unpublishing. It offers an API to do an unpublish similar to the "publish" one. Once invoked, and only if there is a 'released' module revision, the system will unpublish the module and if there is no draft revision set, it will get the latest historical revision for the module and will make it the draft.

To invoke this API:

```
POST /module/path.adoc?:operation=pant:unpublish`
```