### PR TITLE
add an internal endpoint for fetching objects based on identifier

### DIFF
--- a/src/main/java/com/redhat/pantheon/model/module/Module.java
+++ b/src/main/java/com/redhat/pantheon/model/module/Module.java
@@ -1,6 +1,5 @@
 package com.redhat.pantheon.model.module;
 
-import com.redhat.pantheon.model.api.ReferenceField;
 import com.redhat.pantheon.model.api.SlingResource;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
 import org.apache.sling.api.resource.Resource;
@@ -10,10 +9,8 @@ import javax.jcr.RepositoryException;
 import java.util.Locale;
 import java.util.Optional;
 
-import static com.google.common.collect.Streams.stream;
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.counting;
 
 /**
  * The definition of a Module resource in the system.
@@ -115,37 +112,5 @@ public class Module extends SlingResource {
     public Optional<Metadata> getDraftMetadata(final Locale locale) {
         return getDraftRevision(locale)
                 .map(moduleRevision -> moduleRevision.metadata.get());
-    }
-
-    /**
-     * A specific module locale node which houses all the revisions for a specific language in the module.
-     */
-    @JcrPrimaryType("sling:OrderedFolder")
-    public static class ModuleLocale extends SlingResource {
-
-        public final ReferenceField<ModuleRevision> released = referenceField("released", ModuleRevision.class);
-
-        public final ReferenceField<ModuleRevision> draft = referenceField("draft", ModuleRevision.class);
-
-        public ModuleRevision getRevision(String name) {
-            return child(name, ModuleRevision.class).get();
-        }
-
-        public ModuleRevision getOrCreateRevision(String name) {
-            return child(name, ModuleRevision.class).getOrCreate();
-        }
-
-        public ModuleRevision createNextRevision() {
-            // Generate a new revision name
-            return child(generateNextRevisionName(), ModuleRevision.class).create();
-        }
-
-        private String generateNextRevisionName() {
-            return "" + (stream(this.getChildren()).collect(counting()) + 1);
-        }
-
-        public ModuleLocale(@Nonnull Resource resource) {
-            super(resource);
-        }
     }
 }

--- a/src/main/java/com/redhat/pantheon/model/module/ModuleLocale.java
+++ b/src/main/java/com/redhat/pantheon/model/module/ModuleLocale.java
@@ -1,0 +1,43 @@
+package com.redhat.pantheon.model.module;
+
+import com.redhat.pantheon.model.api.ReferenceField;
+import com.redhat.pantheon.model.api.SlingResource;
+import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
+import org.apache.sling.api.resource.Resource;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.collect.Streams.stream;
+import static java.util.stream.Collectors.counting;
+
+/**
+ * A specific module locale node which houses all the revisions for a specific language in the module.
+ */
+@JcrPrimaryType("pant:moduleLocale")
+public class ModuleLocale extends SlingResource {
+
+    public final ReferenceField<ModuleRevision> released = referenceField("released", ModuleRevision.class);
+
+    public final ReferenceField<ModuleRevision> draft = referenceField("draft", ModuleRevision.class);
+
+    public ModuleLocale(@Nonnull Resource resource) {
+        super(resource);
+    }
+
+    public ModuleRevision getRevision(String name) {
+        return child(name, ModuleRevision.class).get();
+    }
+
+    public ModuleRevision getOrCreateRevision(String name) {
+        return child(name, ModuleRevision.class).getOrCreate();
+    }
+
+    public ModuleRevision createNextRevision() {
+        // Generate a new revision name
+        return child(generateNextRevisionName(), ModuleRevision.class).create();
+    }
+
+    private String generateNextRevisionName() {
+        return "" + (stream(this.getChildren()).collect(counting()) + 1);
+    }
+}

--- a/src/main/java/com/redhat/pantheon/servlet/GetObjectByUUID.java
+++ b/src/main/java/com/redhat/pantheon/servlet/GetObjectByUUID.java
@@ -36,7 +36,7 @@ import static com.redhat.pantheon.servlet.ServletUtils.*;
                 Constants.SERVICE_DESCRIPTION + "=Servlet which allows querying of any object via their UUID",
                 Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
         })
-@SlingServletPaths(value = "/pantheon/internal/object.json")
+@SlingServletPaths(value = "/pantheon/internal/node.json")
 public class GetObjectByUUID extends SlingSafeMethodsServlet {
 
     final String UUID_PARAM = "uuid";

--- a/src/main/java/com/redhat/pantheon/servlet/GetObjectByUUID.java
+++ b/src/main/java/com/redhat/pantheon/servlet/GetObjectByUUID.java
@@ -1,0 +1,79 @@
+package com.redhat.pantheon.servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.redhat.pantheon.servlet.ServletUtils.*;
+
+/**
+ * Simple servlet which aims to provide an internal way to quickly access resources by their UUID. This servlet is
+ * read-only, and the returned content is in json format. This servlet also offers the capability of deep diving into
+ * the resource's children by providing a 'depth' parameter.
+ *
+ * @author Carlos Munoz
+ */
+@Component(
+        service = Servlet.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=Servlet which allows querying of any object via their UUID",
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+        })
+@SlingServletPaths(value = "/pantheon/internal/object.json")
+public class GetObjectByUUID extends SlingSafeMethodsServlet {
+
+    final String UUID_PARAM = "uuid";
+    final String DEPTH_PARAM = "depth";
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        String uuid = paramValue(request, UUID_PARAM);
+        Long depth = paramValueAsLong(request, DEPTH_PARAM, 0L);
+
+        if(isNullOrEmpty(uuid)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Parameter '" + UUID_PARAM + "' must be provided");
+            return;
+        } else if (depth < 0) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Parameter '" + DEPTH_PARAM + "' must be >= 0");
+            return;
+        }
+
+        try {
+            Node foundNode = request.getResourceResolver()
+                    .adaptTo(Session.class)
+                    .getNodeByIdentifier(uuid);
+
+            // turn the node back into a resource
+            Resource foundResource = request.getResourceResolver()
+                    .getResource(foundNode.getPath());
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            options.setAddSelectors("." + depth);
+            RequestDispatcher requestDispatcher =
+                    request.getRequestDispatcher(foundResource.getPath() + ".json", options);
+            requestDispatcher.include(request, response);
+        } catch (ItemNotFoundException infex) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        } catch (RepositoryException e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
+++ b/src/main/java/com/redhat/pantheon/servlet/module/ReleaseDraftRevision.java
@@ -3,7 +3,7 @@ package com.redhat.pantheon.servlet.module;
 import com.redhat.pantheon.conf.GlobalConfig;
 import com.redhat.pantheon.extension.Events;
 import com.redhat.pantheon.model.module.Module;
-import com.redhat.pantheon.model.module.Module.ModuleLocale;
+import com.redhat.pantheon.model.module.ModuleLocale;
 import com.redhat.pantheon.model.module.ModuleRevision;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.servlets.post.AbstractPostOperation;

--- a/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
+++ b/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
@@ -42,6 +42,9 @@
 [pant:module] > nt:unstructured, sling:Resource, mix:referenceable, mix:created, mix:lastModified
     - sling:resourceType (string) = 'pantheon/module' mandatory autocreated
 
+[pant:moduleLocale] > nt:unstructured, sling:Resource, mix:referenceable, mix:created, mix:lastModified
+ - sling:resourceType (string) = 'pantheon/moduleLocale' mandatory autocreated
+
 [pant:moduleRevision] > nt:unstructured, sling:Resource, mix:referenceable, mix:created, mix:lastModified
     - sling:resourceType (string) = 'pantheon/moduleVersion' mandatory autocreated
 

--- a/src/test/java/com/redhat/pantheon/servlet/GetObjectByUUIDTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/GetObjectByUUIDTest.java
@@ -1,0 +1,104 @@
+package com.redhat.pantheon.servlet;
+
+import org.apache.http.HttpStatus;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.apache.sling.testing.mock.sling.servlet.MockRequestDispatcherFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class, SlingContextExtension.class})
+class GetObjectByUUIDTest {
+
+    SlingContext sCtx = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    MockRequestDispatcherFactory dispatcherFactory;
+
+    @Test
+    void doGet() throws ServletException, IOException {
+        // Given
+        sCtx.create().resource("/test",
+                "name", "a-name",
+                "jcr:mixinTypes", "mix:referenceable");
+        sCtx.create().resource("/test/child",
+                "name", "child-name");
+        sCtx.request().setRequestDispatcherFactory(dispatcherFactory);
+        String resourceUuid = sCtx.resourceResolver()
+                .getResource("/test")
+                .getValueMap()
+                .get("jcr:uuid")
+                .toString();
+        Map params = newHashMap();
+        params.put("uuid", resourceUuid);
+        params.put("depth",  "2");
+        sCtx.request().setParameterMap(params);
+        GetObjectByUUID servlet = new GetObjectByUUID();
+
+        // When
+        servlet.doGet(sCtx.request(), sCtx.response());
+
+        // Then
+        assertEquals(HttpStatus.SC_OK, sCtx.response().getStatus());
+        verify(dispatcherFactory, times(1)).getRequestDispatcher(eq("/test.json"), any());
+    }
+
+    @Test
+    void doGetNonexistentResource() throws ServletException, IOException {
+        // Given
+        Map params = newHashMap();
+        params.put("uuid", UUID.randomUUID().toString());
+        sCtx.request().setParameterMap(params);
+        GetObjectByUUID servlet = new GetObjectByUUID();
+
+        // When
+        servlet.doGet(sCtx.request(), sCtx.response());
+
+        // Then
+        assertEquals(HttpStatus.SC_NOT_FOUND, sCtx.response().getStatus());
+    }
+
+    @Test
+    void doGetWithNoUUID() throws ServletException, IOException {
+        // Given
+        GetObjectByUUID servlet = new GetObjectByUUID();
+
+        // When
+        servlet.doGet(sCtx.request(), sCtx.response());
+
+        // Then
+        assertEquals(HttpStatus.SC_BAD_REQUEST, sCtx.response().getStatus());
+    }
+
+    @Test
+    void doGetWithInvalidDepth() throws ServletException, IOException {
+        // Given
+        Map params = newHashMap();
+        params.put("uuid", UUID.randomUUID().toString());
+        params.put("depth", "-1");
+        sCtx.request().setParameterMap(params);
+        GetObjectByUUID servlet = new GetObjectByUUID();
+
+        // When
+        servlet.doGet(sCtx.request(), sCtx.response());
+
+        // Then
+        assertEquals(HttpStatus.SC_BAD_REQUEST, sCtx.response().getStatus());
+    }
+}


### PR DESCRIPTION
Add a simple application internal endpoint capable of retrieving any object by unique identifier (jcr:uuid field). The endpoint returns objects in json format and behaves in the following manner:

```
GET /pantheon/internal/node.json?uuid=<some uuid>&depth=3
```
**Parameters**
uuid: The unique identifier of the object in question
depth: An integer greater than 0 indicating the number of child levels to fetch with the resource.

**Return codes**
200: along with the json representation of the resource
404: If no resource is found for the provided uuid
400: If any of the provided parameters are missing or invalid.

This API does not make any guarantees about the json structure being returned. Callers should know the structure of the resource being fetched.