### PR TITLE
CCS-2975: replace module abstract extraction for an attribute-based approach

### DIFF
--- a/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorService.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorService.java
@@ -3,6 +3,7 @@ package com.redhat.pantheon.asciidoctor;
 import com.google.common.base.Charsets;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
+import com.redhat.pantheon.asciidoctor.extension.ContentAbstractBlockProcessor;
 import com.redhat.pantheon.asciidoctor.extension.MetadataExtractorTreeProcessor;
 import com.redhat.pantheon.conf.GlobalConfig;
 import com.redhat.pantheon.model.api.FileResource;
@@ -136,6 +137,8 @@ public class AsciidoctorService {
         try {
             asciidoctor.javaExtensionRegistry().treeprocessor(
                     new MetadataExtractorTreeProcessor(metadata));
+            asciidoctor.javaExtensionRegistry().block(
+                    new ContentAbstractBlockProcessor(metadata));
 
             asciidoctor.load(content.jcrData.get(), newHashMap());
         }

--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/ContentAbstractBlockProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/ContentAbstractBlockProcessor.java
@@ -1,0 +1,46 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.model.module.Metadata;
+import org.asciidoctor.ast.ContentModel;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.Contexts;
+import org.asciidoctor.extension.Name;
+import org.asciidoctor.extension.Reader;
+
+import java.util.Map;
+
+import static org.asciidoctor.ast.ContentModel.SIMPLE;
+import static org.asciidoctor.extension.Contexts.PARAGRAPH;
+
+/**
+ * A block processor which extracts the abstract from an asciidoc file.
+ * A paragraph must be given the named attribute called 'pantheon:abstract' for the system
+ * to record it as the abstract in the metadata, like so:
+ *
+ * [..., pantheon:abstract, ...]
+ * This is the abstract content
+ *
+ * If multiple paragraphs are marked with this attribute in a single module, there is no
+ * guarantee any of them will be chosen as the abstract, although one of them will. This means
+ * only one paragraph should be marked with this attribute.
+ */
+@Name("pantheon:abstract")
+@Contexts(PARAGRAPH)
+@ContentModel(SIMPLE)
+public class ContentAbstractBlockProcessor extends BlockProcessor {
+
+    private final Metadata metadata;
+
+    public ContentAbstractBlockProcessor(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
+        metadata.mAbstract.set(reader.read());
+        // NOTE This extension should only be used for metadata extraction and NOT during content generation;
+        //  there is no need to create a block
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -44,7 +44,6 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
     @Override
     public Document process(Document document) {
         extractDocTitle(document);
-        extractAbstract(document);
         extractHeadline(document);
         return document;
     }
@@ -57,29 +56,6 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
         String docTitle = document.getDoctitle();
         if(!isNullOrEmpty(docTitle)) {
             metadata.title.set(docTitle);
-        }
-    }
-
-    /**
-     * Extracts the document's abstract from an asciidoc document.
-     * The abstract is assumed to be the first paragraph of text in the document.
-     * @param document
-     */
-    private void extractAbstract(Document document) {
-        Optional<String> abstractContent = document.getBlocks().stream()
-                // find the first content block
-                .findFirst()
-                // only the first paragraph is allowed, all other blocks are ignored
-                .filter(block -> block.getContext().equals("paragraph"))
-                // make sure it has some content
-                .filter(contentBlock -> !isNullOrEmpty(contentBlock.getContent().toString()))
-                // get the content itself
-                .map(contentBlock -> contentBlock.getContent().toString());
-        abstractContent.ifPresent(content -> metadata.mAbstract.set(content));
-
-        // If no abstract is detected, reset it
-        if(!abstractContent.isPresent()) {
-            metadata.mAbstract.set(null);
         }
     }
 

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/ContentAbstractBlockProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/ContentAbstractBlockProcessorTest.java
@@ -1,0 +1,63 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.model.module.Metadata;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.asciidoctor.Asciidoctor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({SlingContextExtension.class})
+class ContentAbstractBlockProcessorTest {
+
+    SlingContext sc = new SlingContext();
+
+    @Test
+    void process() {
+        // Given
+        sc.build()
+                .resource("/metadata")
+                .commit();
+        String content = "== A title\n" +
+                "\n" +
+                "\n[pantheon:abstract]" +
+                "\nThis is my abstract.";
+        Metadata metadata = new Metadata(sc.resourceResolver().getResource("/metadata"));
+        ContentAbstractBlockProcessor extension = new ContentAbstractBlockProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().block(extension);
+
+        // When
+        asciidoctor.load(content, new HashMap<>());
+
+        // Then
+        assertEquals("This is my abstract.", metadata.mAbstract.get());
+    }
+
+    @Test
+    void noAbstractPresent() {
+        // Given
+        sc.build()
+                .resource("/metadata")
+                .commit();
+        String content = "== A title\n" +
+                "\n" +
+                "\nThis is my abstract.";
+        Metadata metadata = new Metadata(sc.resourceResolver().getResource("/metadata"));
+        ContentAbstractBlockProcessor extension = new ContentAbstractBlockProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().block(extension);
+
+        // When
+        asciidoctor.load(content, new HashMap<>());
+
+        // Then
+        assertNull(metadata.mAbstract.get());
+    }
+}

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
@@ -42,8 +42,6 @@ class MetadataExtractorTreeProcessorTest {
 
         // Then
         assertEquals("A title for content", metadata.title.get());
-        assertEquals("This is the first paragraph which serves as abstract for a module",
-                metadata.mAbstract.get());
     }
 
     @Test

--- a/src/test/java/com/redhat/pantheon/servlet/AsciidocContentRenderingServletTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/AsciidocContentRenderingServletTest.java
@@ -1,0 +1,48 @@
+package com.redhat.pantheon.servlet;
+
+import com.google.common.collect.Maps;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.util.TestUtils;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SlingContextExtension.class)
+class AsciidocContentRenderingServletTest {
+
+    SlingContext sc = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Test
+    void doGet() throws Exception {
+        // Given
+        sc.build()
+                .resource("/module/en_US/1",
+                        "jcr:primaryType", "pant:moduleRevision")
+                .resource("/module/en_US/1/content/asciidoc/jcr:content",
+                        "jcr:data", "some asciidoc content")
+                .commit();
+        registerMockAdapter(Module.class, sc);
+        sc.resourceResolver().getResource("/module/en_US").adaptTo(ModifiableValueMap.class)
+                .put("draft", sc.resourceResolver().getResource("/module/en_US/1").getValueMap().get("jcr:uuid"));
+        AsciidocContentRenderingServlet servlet = new AsciidocContentRenderingServlet();
+        Map<String, Object> params = Maps.newHashMap();
+        params.put("draft", "true");
+        sc.request().setParameterMap(params);
+        sc.request().setResource(sc.resourceResolver().getResource("/module"));
+
+        // When
+        servlet.doGet(sc.request(), sc.response());
+
+        // Then
+        assertTrue(sc.response().getContentType().startsWith("text/plain"));
+        assertEquals("some asciidoc content", sc.response().getOutputAsString());
+    }
+}


### PR DESCRIPTION
This change implements a more accurate way of identifying and extracting a module's abstract, relying on asciidoc's own syntax.

The approach requires the use of a single named attribute on any paragraph in the content to identify the abstract. The attribute's name is `pantheon:abstract` (clearly identifying the application and the purpose) to make sure writers are able to tell the platform where the metadata is without any room for ambiguity.

A sample usage for this would be:

```adoc
= Why using attributes to identify metadata is a good idea

[pantheon:abstract]
It's a good idea to use attributes to identify metadata in the content as it removes any ambiguity when comparing to a positional based approach.
```