### PR TITLE
Use manually set COMMIT_HASH ENV and not the Openshift default one

### DIFF
--- a/src/main/java/com/redhat/pantheon/servlet/BuildDateServlet.java
+++ b/src/main/java/com/redhat/pantheon/servlet/BuildDateServlet.java
@@ -45,16 +45,16 @@ public class BuildDateServlet extends SlingSafeMethodsServlet {
         }
     }
 
-    protected String getDate(){ 
+    protected String getDate(){
         return PlatformData.getJarBuildDate();
     }
 
     protected String getCommitHash(){
         String commitHash;
-        if (System.getenv("OPENSHIFT_BUILD_COMMIT") != null){
-            commitHash = System.getenv("OPENSHIFT_BUILD_COMMIT");
+        if (System.getenv("COMMIT_HASH") != null){
+            commitHash = System.getenv("COMMIT_HASH");
         } else {
-            commitHash = "OPENSHIFT_BUILD_COMMIT is not set, this might not be an OpenShift environment.";
+            commitHash = "COMMIT_HASH is not set, this might not be an OpenShift environment.";
         }
         return commitHash;
     }

--- a/src/test/java/com/redhat/pantheon/servlet/BuildDateServletTest.java
+++ b/src/test/java/com/redhat/pantheon/servlet/BuildDateServletTest.java
@@ -16,10 +16,10 @@ public class BuildDateServletTest {
     public void testBuilddate() throws Exception {
         //Given
         BuildDateServlet buildDate = new BuildDateServlet();
-        
+
         //When
         String date = buildDate.getDate();
-        
+
         //Then
         assertEquals(true,date.contains(""));
     }
@@ -34,6 +34,6 @@ public class BuildDateServletTest {
         String hash = buildDate.getCommitHash();
 
         //Then
-        assertEquals(true, hash.contains("OPENSHIFT_BUILD_COMMIT is not set"));
+        assertEquals(true, hash.contains("COMMIT_HASH is not set"));
     }
 }


### PR DESCRIPTION
This is needed because of how we are setting proxies now on the builds internally.