### PR TITLE
CCS-3176: Prevent generation errors when using one of Pantheon's custom extensions

### DIFF
--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -77,7 +77,7 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
                         return block.getContext().equals("section") && block.getLevel() == 1;
                     } catch (Exception e) {
                         // Asciidoctor (the Ruby code) throws certain exceptions when properties are not available.
-                        // In this case 'context' might not be available, so in that case the filter should just
+                        // In this case 'context' might not be available, and so the filter should just
                         // return false
                         return false;
                     }

--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.asciidoctor.extension;
 
 import com.google.common.collect.Streams;
 import com.redhat.pantheon.model.module.Metadata;
+import com.redhat.pantheon.util.function.FunctionalUtils;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.StructuralNode;
@@ -74,7 +75,16 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
         // Get the first section (that's where a subtitle will be)
         Optional<StructuralNode> headlineBlock = nodeFlatMap(document)
                 // find section blocks with level == 1
-                .filter(block -> block.getContext().equals("section") && block.getLevel() == 1)
+                .filter(block -> {
+                    try {
+                        return block.getContext().equals("section") && block.getLevel() == 1;
+                    } catch (Exception e) {
+                        // Asciidoctor (the Ruby code) throws certain exceptions when properties are not available.
+                        // In this case 'context' might not be available, so in that case the filter should just
+                        // return false
+                        return false;
+                    }
+                })
                 .findFirst();
         headlineBlock.ifPresent(headline -> metadata.headline.set(headline.getTitle()));
 

--- a/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -1,9 +1,6 @@
 package com.redhat.pantheon.asciidoctor.extension;
 
-import com.google.common.collect.Streams;
 import com.redhat.pantheon.model.module.Metadata;
-import com.redhat.pantheon.util.function.FunctionalUtils;
-import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.Treeprocessor;

--- a/src/main/java/com/redhat/pantheon/util/function/FunctionalUtils.java
+++ b/src/main/java/com/redhat/pantheon/util/function/FunctionalUtils.java
@@ -1,6 +1,5 @@
 package com.redhat.pantheon.util.function;
 
-import javax.annotation.Nullable;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 

--- a/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
+++ b/src/test/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessorTest.java
@@ -97,6 +97,45 @@ class MetadataExtractorTreeProcessorTest {
         assertEquals("Headline", metadata.headline.get());
     }
 
+    /**
+     * CCS-3176
+     * This specific regression test makes sure that when the context property is not available in a given block,
+     * the extension code doesn't fail. This has been observed when the content has a data list
+     */
+    @Test
+    void extractHeadlineWithException() {
+        // Given
+        slingContext.build()
+                .resource("/content/module1/locales/en_US/1/metadata")
+                .commit();
+        Metadata metadata =
+                new Metadata(
+                        slingContext.resourceResolver().getResource(
+                                "/content/module1/locales/en_US/1/metadata"));
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent =
+                "`GTC` — Generic Token Card.\n" +
+                "\n" +
+                "`Username`::\n" +
+                "+\n" +
+                "Enter the user name to be used in the authentication process.\n" +
+                "\n" +
+                "`Password`::\n" +
+                "+\n" +
+                "Enter the password to be used in the authentication process.\n" +
+                "\n" +
+                "[[bh-Configuring_Protected_EAP_PEAP_Settings]]\n" +
+                "[discrete]\n";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertNull(metadata.headline.get());
+    }
+
     @Test
     void extractHeadlineNotPresent() {
         // Given


### PR DESCRIPTION
The `MetadataExtractorTreeProcessor` could throw an exception under certain conditions. In general, the underlying asciidoctor ruby implementation could throw exceptions when calling java methods which do not apply in certain situations (e.g. `getContext()`), instead of failing gracefully. This pull request accounts for that scenario.