### PR TITLE
add slingstart documentation and references

### DIFF
--- a/pantheon-slingstart/README.md
+++ b/pantheon-slingstart/README.md
@@ -1,0 +1,1 @@
+Provisioning files taken directly (and in some cases modified) from https://github.com/apache/sling-org-apache-sling-starter 

--- a/pantheon-slingstart/pom.xml
+++ b/pantheon-slingstart/pom.xml
@@ -27,6 +27,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <createWebapp>true</createWebapp>
+                    <modelDirectory>${basedir}/src/main/provisioning</modelDirectory>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
add a reference to the original slingstart project from where the provisioning
model files where originally sourced, and add a default parameter when using
the sling maven plugin for developer clarity