### PR TITLE
CCS-3208: add a static image delivery mechanism

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -7,8 +7,9 @@ COPY ../pantheon-slingstart/target/pantheon-slingstart-*.jar /opt/sling/pantheon
 
 WORKDIR /opt/sling/
 EXPOSE 8080
+EXPOSE 5005
 
-ENV JAVA_OPTS -Xmx1024m
+ENV JAVA_OPTS -Xmx1024m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 ENV SLING_OPS ''
 
 CMD export COMMIT_HASH=$(cat /opt/sling/commit_hash); java $JAVA_OPTS -jar pantheon.jar $SLING_OPTS

--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -400,6 +400,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <artifactId>oak-commons</artifactId>
+            <version>1.8.8</version>
+            <groupId>org.apache.jackrabbit</groupId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.log</artifactId>
             <version>5.1.10</version>

--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -272,6 +272,11 @@
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.12.1</version>
+        </dependency>
 
         <!-- Provided dependencies -->
         <dependency>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorPool.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorPool.java
@@ -1,5 +1,6 @@
 package com.redhat.pantheon.asciidoctor;
 
+import com.redhat.pantheon.asciidoctor.extension.ImageSrcTransformer;
 import com.redhat.pantheon.asciidoctor.extension.SlingResourceIncludeProcessor;
 import com.redhat.pantheon.conf.GlobalConfig;
 import com.redhat.pantheon.util.pool.ObjectPool;
@@ -51,6 +52,8 @@ public class AsciidoctorPool extends ObjectPool<Asciidoctor> {
             // TODO - extensions, and then this try/catch->returnObject construct can disappear as well.
             asciidoctor.javaExtensionRegistry().includeProcessor(
                     new SlingResourceIncludeProcessor(base));
+            asciidoctor.javaExtensionRegistry().postprocessor(
+                    new ImageSrcTransformer(base));
             return asciidoctor;
         } catch (Exception e) {
             returnObject(asciidoctor);

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformer.java
@@ -1,0 +1,52 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Postprocessor;
+import org.jsoup.Jsoup;
+
+import java.util.Base64;
+
+import static com.redhat.pantheon.conf.GlobalConfig.IMAGE_PATH_PREFIX;
+
+/**
+ * An asciidoctor post processor which transforms all image locations in the resulting html to an encoded and absolutely
+ * resolving path comprised of a prefix and a unique identifier for the image. This unique identifier consists of the
+ * Base64 encoding of the actual absolute path of the image resource in the JCR repository.
+ *
+ * @see com.redhat.pantheon.servlet.assets.ImageServletFilter for the servlet serving these paths
+ * @author Carlos Munoz
+ */
+public class ImageSrcTransformer extends Postprocessor {
+
+    private final Resource module;
+
+    public ImageSrcTransformer(Resource module) {
+        this.module = module;
+    }
+
+    @Override
+    public String process(Document document, String output) {
+        org.jsoup.nodes.Document doc = Jsoup.parse(output, "UTF-8");
+
+        ResourceResolver resourceResolver = module.getResourceResolver();
+
+        // add a prefix to all images
+        doc.select("img")
+                .forEach(imageElement -> {
+                    String imgSrc = imageElement.attr("src");
+                    Resource resolvedImage = resourceResolver.getResource(module.getParent(), imgSrc);
+                    if(resolvedImage != null) {
+                        imageElement.attr("src", encodeImgSrc(resolvedImage.getPath()));
+                    }
+                });
+        output = doc.html();
+
+        return output;
+    }
+
+    String encodeImgSrc(String imageResourcePath) {
+        return IMAGE_PATH_PREFIX + "/" + Base64.getUrlEncoder().encodeToString(imageResourcePath.getBytes());
+    }
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformer.java
@@ -1,5 +1,6 @@
 package com.redhat.pantheon.asciidoctor.extension;
 
+import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.asciidoctor.ast.Document;
@@ -36,10 +37,8 @@ public class ImageSrcTransformer extends Postprocessor {
         doc.select("img")
                 .forEach(imageElement -> {
                     String imgSrc = imageElement.attr("src");
-                    Resource resolvedImage = resourceResolver.getResource(module.getParent(), imgSrc);
-                    if(resolvedImage != null) {
-                        imageElement.attr("src", encodeImgSrc(resolvedImage.getPath()));
-                    }
+                    String imagePath = PathUtils.concat(module.getParent().getPath(), imgSrc);
+                    imageElement.attr("src", encodeImgSrc(imagePath));
                 });
         output = doc.html();
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/conf/GlobalConfig.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/conf/GlobalConfig.java
@@ -39,6 +39,8 @@ public class GlobalConfig {
 
     public static final String CONTENT_TYPE = "documentation";
 
+    public static final String IMAGE_PATH_PREFIX = "/imageassets";
+
     private final LoadableValue<List<String>> GEM_PATHS = new LoadableValue<>(this::loadGemPaths);
 
     private final LoadableValue<Optional<File>> TEMPLATE_DIRECTORY =

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assets/ImageServletFilter.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assets/ImageServletFilter.java
@@ -1,0 +1,57 @@
+package com.redhat.pantheon.servlet.assets;
+
+import org.apache.sling.servlets.annotations.SlingServletFilter;
+import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Base64;
+
+import static com.redhat.pantheon.conf.GlobalConfig.IMAGE_PATH_PREFIX;
+
+/**
+ * A servlet filter which serves image assets only. Images must be referened using an absolute path comprised
+ * of a prefix (see @{link IMAGE_PATH_PREFIX} for the exact value) plus an identifier. In this servlet the identifier is
+ * a Base64 encoding of the actual path stored in the JCR repository for the image.
+ * </br>
+ * </br>
+ * So for example, an image path might be:
+ * http://my.server/imageassets/L2NvbnRlbnQvcmVwb3NpdG9yaWVzL3BhbnRoZW9uU2FtcGxlUmVwby9pbWFnZXMvdGlnZXIucG5n
+ * with /imageassets being the prefix and everything after (exluding the separating slash) being a Base64 encoding of the
+ * path: /content/repositories/pantheonSampleRepo/images/tiger.png which resolves absolutely and unambigously to an image
+ * in the system.
+ *
+ * @author Carlos Munoz
+ */
+@Component(
+        service = Filter.class
+)
+@SlingServletFilter(
+        methods = "GET",
+        pattern = "/imageassets/.*")
+public class ImageServletFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // Get the id, everything after the prefix
+        String contextPath = ((HttpServletRequest)request).getPathInfo();
+        contextPath = contextPath.substring((IMAGE_PATH_PREFIX + "/").length());
+
+        String imagePath = new String(Base64.getUrlDecoder().decode(contextPath));
+        request.getRequestDispatcher(imagePath)
+            .forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformerTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformerTest.java
@@ -1,0 +1,67 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.conf.GlobalConfig;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.asciidoctor.ast.Document;
+import org.jsoup.Jsoup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(SlingContextExtension.class)
+class ImageSrcTransformerTest {
+
+    final Pattern imageRegEx = Pattern.compile(GlobalConfig.IMAGE_PATH_PREFIX + "/.*");
+
+    SlingContext sc = new SlingContext();
+
+    @Test
+    void process() {
+        // Given
+        final String html = "<html>" +
+                "This is a sample html" +
+                "<p>" +
+                "with a single image " +
+                "<img src='some/image/path'>" +
+                "</p>" +
+                "</html>";
+        sc.build()
+                .resource("/a/module")
+                .resource("/a/some/image/path")
+                .commit();
+        ImageSrcTransformer transformer = new ImageSrcTransformer(sc.resourceResolver().getResource("/a/module"));
+
+        // When
+        String processedOutput = transformer.process(mock(Document.class), html);
+
+        // Then
+        assertNotEquals(html, processedOutput);
+        org.jsoup.nodes.Document doc = Jsoup.parse(processedOutput, "UTF-8");
+        assertFalse(doc.select("img").isEmpty());
+        doc.select("img").forEach(image -> {
+            assertTrue(image.attr("src").matches(imageRegEx.pattern()));
+        });
+    }
+
+    @Test
+    void encodeImgSrc() {
+        // Given
+        String path1 = "/a/content/image.png";
+        String path2 = "../../a/relative/image.jpg";
+
+        // When
+        ImageSrcTransformer transformer = new ImageSrcTransformer(mock(Resource.class));
+
+        // Then
+        assertTrue(imageRegEx.matcher(transformer.encodeImgSrc(path1)).matches());
+        assertTrue(imageRegEx.matcher(transformer.encodeImgSrc(path2)).matches());
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformerTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ImageSrcTransformerTest.java
@@ -8,9 +8,7 @@ import org.asciidoctor.ast.Document;
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 
-import java.util.Base64;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,6 +29,8 @@ class ImageSrcTransformerTest {
                 "<p>" +
                 "with a single image " +
                 "<img src='some/image/path'>" +
+                "<img src='./some/image/path'>" +
+                "<img src='../nonexistent/image/path'>" +
                 "</p>" +
                 "</html>";
         sc.build()

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assets/ImageServletFilterTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assets/ImageServletFilterTest.java
@@ -1,0 +1,57 @@
+package com.redhat.pantheon.servlet.assets;
+
+import com.redhat.pantheon.conf.GlobalConfig;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.apache.sling.testing.mock.sling.servlet.MockRequestDispatcherFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({SlingContextExtension.class, MockitoExtension.class})
+class ImageServletFilterTest {
+
+    SlingContext sc = new SlingContext();
+
+    @Mock
+    FilterChain filterChain;
+
+    @Mock
+    MockRequestDispatcherFactory requestDispatcherFactory;
+
+    @Test
+    void doFilter() throws Exception {
+        // Given
+        String imagePath = "/path/to/my/image.png";
+        sc.build()
+                .resource(imagePath)
+                .commit();
+        String imageUrl = Base64.getUrlEncoder().encodeToString(imagePath.getBytes());
+        RequestDispatcher requestDispatcher = mock(RequestDispatcher.class);
+        sc.request().setRequestDispatcherFactory(requestDispatcherFactory);
+        sc.request().setPathInfo(GlobalConfig.IMAGE_PATH_PREFIX + "/" + imageUrl);
+        when(requestDispatcherFactory.getRequestDispatcher(anyString(), any())).thenReturn(requestDispatcher);
+        ImageServletFilter filter = new ImageServletFilter();
+
+        // When
+        filter.init(mock(FilterConfig.class));
+        filter.doFilter(sc.request(), sc.response(), filterChain);
+
+        // Then
+        verify(requestDispatcherFactory).getRequestDispatcher(eq(imagePath), any());
+        verify(requestDispatcher).forward(any(), any());
+    }
+}


### PR DESCRIPTION
Create a static image delivery mechanism for proxies and edge platforms. The mechanism consists of two parts:

1. A re-encoding of all generated `<img>` tags in the generated html so that they refer to images in an absolute way. The resulting html will have image tags of the form:
`<img src="/imageassets/{unique image id}">` with `{unique image id}` being a url friendly string by which the image can be uniquely identified in the system.

2. A system endpoint capable of handling the requested image asset urls, decoding the unique identifier and serving the image properly.

This mechanism should allow the edge to detect calls to the unique prefix in the system and route them appropriately to pantheon for subsequent caching.