### PR TITLE
Check for COMMIT_HASH instead of OPENSHIFT specific ENV VAR

### DIFF
--- a/tools/git2pantheon/main.go
+++ b/tools/git2pantheon/main.go
@@ -69,11 +69,11 @@ func getInfo(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "GET" {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 
-		var response = os.Getenv("OPENSHIFT_BUILD_COMMIT")
+		var response = os.Getenv("COMMIT_HASH")
 		if response == "" {
 			response = "not set"
 		}
-		fmt.Fprint(w, "OPENSHIFT_BUILD_COMMIT is : "+response)
+		fmt.Fprint(w, "COMMIT_HASH is : "+response)
 	} else {
 		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
 	}

--- a/tools/git2pantheon/main_test.go
+++ b/tools/git2pantheon/main_test.go
@@ -41,7 +41,7 @@ func TestGetInfo(t *testing.T) {
 	fmt.Println(string(body))
 
 	if !strings.Contains(string(body), "not set") {
-		t.Errorf("ENV OPENSHIFT_BUILD_COMMIT should always be not set during build.")
+		t.Errorf("ENV COMMIT_HASH should always be not set during build.")
 	}
 
 	req = httptest.NewRequest("POST", "http://example.com/info", nil)


### PR DESCRIPTION
This follows the same method we are using for the pantheon2 backend.