### PR TITLE
A few changes to module json enrichment

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/conf/GlobalConfig.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/conf/GlobalConfig.java
@@ -37,7 +37,7 @@ public class GlobalConfig {
 
     public static final Locale DEFAULT_MODULE_LOCALE = Locale.US;
 
-    public static final String CONTENT_TYPE = "documentation";
+    public static final String CONTENT_TYPE = "module";
 
     public static final String IMAGE_PATH_PREFIX = "/imageassets";
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
@@ -98,6 +98,7 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         moduleMap.put("description", releasedMetadata.get().description().get());
         moduleMap.put("content_type", CONTENT_TYPE);
         moduleMap.put("date_published", releasedMetadata.get().getValueMap().containsKey("pant:datePublished") ? releasedMetadata.get().datePublished().get().toInstant().toString() : "");
+        moduleMap.put("status", "published");
 
         // Assume the path is something like: /content/<something>/my/resource/path
         moduleMap.put("module_url_fragment", resourcePath.substring("/content/repositories/".length(), resourcePath.length()));
@@ -135,6 +136,7 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         if (!urlFragment.isEmpty()) {
             moduleMap.put("vanity_url_fragment", urlFragment);
         }
+
         // remove unnecessary fields from the map
         moduleMap.remove("jcr:lastModified");
         moduleMap.remove("jcr:lastModifiedBy");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
@@ -104,6 +104,7 @@ class ModuleJsonServletTest {
         assertTrue(moduleMap.containsKey("content_type"));
         assertTrue(moduleMap.containsKey("date_modified"));
         assertTrue(moduleMap.containsKey("date_published"));
+        assertTrue(moduleMap.containsKey("status"));
         assertTrue(moduleMap.containsKey("context_id"));
         assertTrue(moduleMap.containsKey("headline"));
         assertTrue(moduleMap.containsKey("module_url_fragment"));


### PR DESCRIPTION
- Changes the content type to `module`
This is done in accordance with Charle's comment - https://projects.engineering.redhat.com/browse/UNIFIED-5409?focusedCommentId=1974799&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1974799

- Adds a new field `status` which is defaulted to "published" - this field will be used to denote if a module is published or unpublished. The event can then be used by any system consuming with the enrichment API.
This was changed as per the discussions on Team Call date: 27th Nov 2019 (Please see docs tooling meeting notes)
