### PR TITLE
Ccs 2972 add solr command in messages

### DIFF
--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -178,12 +178,12 @@ class Versions extends Component<IProps, any> {
                                                                     {data.version}
                                                                 </DataListCell>,
                                                                 <DataListCell key={'published_value_' + key1 + '_' + key2}>
-                                                                    {data.publishedState==="Not published" && data.publishedState}
-                                                                    {data.publishedState==="Released" && data.updatedDate}
+                                                                    {data.publishedState === "Not published" && data.publishedState}
+                                                                    {data.publishedState === "Released" && data.updatedDate}
                                                                 </DataListCell>,
                                                                 <DataListCell key={'version_updated_' + key1 + '_' + key2}>
-                                                                    {data["type"]==="draft" && (data["updatedDate"].trim() !== "" ? data.updatedDate : "-")}
-                                                                    {data["type"]==="release" && (data["draftUploadDate"].trim() !== "" ? data.draftUploadDate : "-")}
+                                                                    {data["type"] === "draft" && (data["updatedDate"].trim() !== "" ? data.updatedDate : "-")}
+                                                                    {data["type"] === "release" && (data["draftUploadDate"].trim() !== "" ? data.draftUploadDate : "-")}
                                                                 </DataListCell>,
                                                                 <DataListCell key={'publish_buttons_' + key1 + '_' + key2}>
                                                                     <Button variant="primary" onClick={() => this.changePublishState(data.firstButtonText)}>{data.firstButtonText}</Button>{'  '}
@@ -232,8 +232,8 @@ class Versions extends Component<IProps, any> {
                                                                     <span className="sp-prop-nosort" id="span-source-type-upload-time">Upload Time</span>
                                                                 </DataListCell>,
                                                                 <DataListCell key={"details_updated_" + key1 + '_' + key2} width={4}>
-                                                                    {data["type"]==="draft" && (data["updatedDate"].trim() !== "" ? data.updatedDate : "-")}
-                                                                    {data["type"]==="release" && (data["draftUploadDate"].trim() !== "" ? data.draftUploadDate : "-")}
+                                                                    {data["type"] === "draft" && (data["updatedDate"].trim() !== "" ? data.updatedDate : "-")}
+                                                                    {data["type"] === "release" && (data["draftUploadDate"].trim() !== "" ? data.draftUploadDate : "-")}
                                                                 </DataListCell>,
                                                             ]}
                                                         />
@@ -357,17 +357,18 @@ class Versions extends Component<IProps, any> {
     private fetchVersions = () => {
         // TODO: need a better fix for the 404 error.
         if (this.props.modulePath !== '') {
-            const fetchpath = "/content" + this.props.modulePath + "/en_US.harray.3.json"
+            // fetchpath needs to start from modulePath instead of modulePath/en_US.
+            // We need extact the module uuid for customer portal url to the module.
+            const fetchpath = "/content" + this.props.modulePath + ".harray.4.json"
             fetch(fetchpath)
                 .then(response => response.json())
                 .then(responseJSON => {
                     this.setState(updateState => {
-                        const releasedTag = responseJSON.released
-                        const draftTag = responseJSON.draft
-                        const versionCount = responseJSON.__children__.length
-
+                        const releasedTag = responseJSON.__children__[0].released
+                        const draftTag = responseJSON.__children__[0].draft
+                        const versionCount = responseJSON.__children__[0].__children__.length
                         for (let i = versionCount - 1; i > versionCount - 3 && i >= 0; i--) {
-                            const moduleVersion = responseJSON.__children__[i]
+                            const moduleVersion = responseJSON.__children__[0].__children__[i]
                             if (moduleVersion["jcr:uuid"] === draftTag) {
                                 this.draft[0].version = "Version " + moduleVersion.__name__
                                 this.draft[0].metadata = this.getHarrayChildNamed(moduleVersion, "metadata")
@@ -383,10 +384,10 @@ class Versions extends Component<IProps, any> {
                                 // this.props.modulePath starts with a slash
                                 this.release[0].path = "/content" + this.props.modulePath + "/en_US/" + moduleVersion.__name__
                             }
-                            if(releasedTag===undefined){
+                            if (releasedTag === undefined) {
                                 this.release[0].updatedDate = "-"
                             }
-                            this.props.updateDate((this.draft[0].updatedDate !== "" ? this.draft[0].updatedDate : this.release[0].draftUploadDate),this.release[0].updatedDate,this.release[0]["version"], responseJSON['jcr:uuid'])
+                            this.props.updateDate((this.draft[0].updatedDate !== "" ? this.draft[0].updatedDate : this.release[0].draftUploadDate), this.release[0].updatedDate, this.release[0].version, responseJSON['jcr:uuid'])
 
                         }
                         return {
@@ -502,7 +503,7 @@ class Versions extends Component<IProps, any> {
             || this.state.usecaseValue === undefined || this.state.usecaseValue === 'Select Use Case' || this.state.usecaseValue === ''
             || this.state.moduleUrl.trim() === "" || (this.state.versionSelected === '' && this.state.versionValue === '')) {
 
-                this.setState({ isMissingFields: true })
+            this.setState({ isMissingFields: true })
         } else {
             const hdrs = {
                 'Accept': 'application/json',
@@ -537,7 +538,7 @@ class Versions extends Component<IProps, any> {
         }
     }
     private onChangeProduct = (productValue) => {
-        this.setState({ productValue, versionUUID: ''})
+        this.setState({ productValue, versionUUID: '' })
     }
     private onChangeVersion = () => {
 
@@ -651,7 +652,7 @@ class Versions extends Component<IProps, any> {
     }
 
     private dismissNotification = () => {
-            this.setState({ isMissingFields: false })
+        this.setState({ isMissingFields: false })
     }
 
     private hideSuccessAlert = () => {

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -500,10 +500,9 @@ class Versions extends Component<IProps, any> {
         if (this.state.productValue === undefined || this.state.productValue === 'Select a Product' || this.state.productValue === ''
             || this.state.versionUUID === undefined || this.state.versionUUID === 'Select a Version' || this.state.versionUUID === ''
             || this.state.usecaseValue === undefined || this.state.usecaseValue === 'Select Use Case' || this.state.usecaseValue === ''
-            || this.state.moduleUrl.trim() === "" || this.state.versionSelected === '') {
+            || this.state.moduleUrl.trim() === "" || (this.state.versionSelected === '' && this.state.versionValue === '')) {
 
                 this.setState({ isMissingFields: true })
-
         } else {
             const hdrs = {
                 'Accept': 'application/json',
@@ -538,7 +537,7 @@ class Versions extends Component<IProps, any> {
         }
     }
     private onChangeProduct = (productValue) => {
-        this.setState({ productValue })
+        this.setState({ productValue, versionUUID: ''})
     }
     private onChangeVersion = () => {
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/ModulePostPublishHydraIntegration.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/ModulePostPublishHydraIntegration.java
@@ -48,6 +48,9 @@ public class ModulePostPublishHydraIntegration implements EventProcessingExtensi
     private static final String TLS_VERSION = "TLSv1.2";
     private static final String UUID_FIELD = "jcr:uuid";
     private static final String HYDRA_TOPIC = "VirtualTopic.eng.pantheon2.notifications";
+    private static final String ID_KEY = "id";
+    private static final String SOLR_COMMAND_KEY = "solr_command";
+    private static final String SOLR_COMMAND_VALUE = "index";
     public static final Locale DEFAULT_MODULE_LOCALE = Locale.US;
 
     private SSLContext sslContext;
@@ -98,7 +101,8 @@ public class ModulePostPublishHydraIntegration implements EventProcessingExtensi
         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         MessageProducer producer = session.createProducer(session.createTopic(HYDRA_TOPIC));
         String moduleUUID = module.getValueMap().get(UUID_FIELD, String.class);
-        String msg = "{\"id\": " + "\"" + this.getPantheonHost() + PANTHEON_MODULE_API_PATH + moduleUUID +"\"}";
+        String msg = "{\"" + ID_KEY + "\":" + "\"" + this.getPantheonHost() + PANTHEON_MODULE_API_PATH + moduleUUID +"\","
+                + "\"" + SOLR_COMMAND_KEY + "\":" + "\"" + SOLR_COMMAND_VALUE + "\"}";
         producer.send(session.createTextMessage(msg));
         log.info("[" + ModulePostPublishHydraIntegration.class.getSimpleName() + "] message sent: " + session.createTextMessage(msg) );
 
@@ -195,7 +199,7 @@ public class ModulePostPublishHydraIntegration implements EventProcessingExtensi
      * @return StompJmsConnectionFactory
      * @throws Exception
      */
-    private StompJmsConnectionFactory createConnectionFactory() throws Exception {
+    private ConnectionFactory createConnectionFactory() throws Exception {
         byte[] byteArray = Base64.decodeBase64(this.getMesasgeBrokerUserPass().getBytes());
         String decodedPass = new String(byteArray);
         TrustManager[] trustAllCerts = new TrustManager[] {


### PR DESCRIPTION
* This PR adds a solr_command for Module post publish hydra integration. The text message now looks like this:
  {"id": "http://llu.usersys.redhat.com:8080/api/module?locale=en-us&module_id=0e79fdb9-be17-4f61-bf01-1744268b4cea","solr_command":"index"}

it used to be:
  {"id": "http://llu.usersys.redhat.com:8080/api/module?locale=en-us&module_id=0e79fdb9-be17-4f61-bf01-1744268b4cea"}

* It also fixes the "All fields are required" alert problem when changing Document Use Case option in Edit Metadata. Current in master branch, after initial update on 'Edit Metadata', if an authenticated user attempts to change the 'Document use case' option to something else, an alert for "All fields are required" pops up, which is a bug. 

* It also fixes the "View on  Customer Portal" url as well as "Copy Permanent URL" to use the correct module uuid. Currently in master branch, the uuid passed into the above two links for published module is wrong. It's not using the module uuid, instead of it's the module/en_US node uuid. 