### PR TITLE
get moduleType metadata in query

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       onClick={[Function]}
       variant="control"
     >
-      <SortAlphaDownIcon
+      <SortAlphaUpIcon
         color="currentColor"
         noVerticalAlign={false}
         size="sm"

--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
@@ -92,24 +92,24 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       />
       <FormSelectOption
         isDisabled={false}
-        key="Concept"
+        key="CONCEPT"
         label="Concept"
         required={false}
-        value="Concept"
+        value="CONCEPT"
       />
       <FormSelectOption
         isDisabled={false}
-        key="Procedure"
+        key="PROCEDURE"
         label="Procedure"
         required={false}
-        value="Procedure"
+        value="PROCEDURE"
       />
       <FormSelectOption
         isDisabled={false}
-        key="Reference"
+        key="REFERENCE"
         label="Reference"
         required={false}
-        value="Reference"
+        value="REFERENCE"
       />
     </FormSelect>
     <FormSelect
@@ -137,13 +137,6 @@ exports[`SearchFilter tests should render default Search component 1`] = `
         label="Title"
         required={false}
         value="Title"
-      />
-      <FormSelectOption
-        isDisabled={false}
-        key="Product"
-        label="Product"
-        required={false}
-        value="Product"
       />
       <FormSelectOption
         isDisabled={false}

--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
@@ -140,13 +140,6 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       />
       <FormSelectOption
         isDisabled={false}
-        key="Published date"
-        label="Published date"
-        required={false}
-        value="Published date"
-      />
-      <FormSelectOption
-        isDisabled={false}
         key="Updated date"
         label="Updated date"
         required={false}

--- a/pantheon-bundle/frontend/src/app/searchFilter.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.tsx
@@ -97,7 +97,7 @@ class SearchFilter extends Component<any, any> {
           </FormSelect>
 
           <Button onClick={this.setSortedUp} variant={ButtonVariant.control} aria-label="search button for search input">
-            {this.state.isSortedUp ? <SortAlphaDownIcon /> : <SortAlphaUpIcon />}
+            {this.state.isSortedUp ? <SortAlphaUpIcon /> : <SortAlphaDownIcon />}
           </Button>
 
 

--- a/pantheon-bundle/frontend/src/app/searchFilter.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.tsx
@@ -55,7 +55,6 @@ class SearchFilter extends Component<any, any> {
     const sortItems = [
       { value: 'Uploaded date', label: 'Uploaded date', disabled: false },
       { value: 'Title', label: 'Title', disabled: false },
-      { value: 'Published date', label: 'Published date', disabled: false },
       { value: 'Updated date', label: 'Updated date', disabled: false },
       { value: 'Module type', label: 'Module type', disabled: false }
     ]

--- a/pantheon-bundle/frontend/src/app/searchFilter.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.tsx
@@ -47,15 +47,14 @@ class SearchFilter extends Component<any, any> {
 
     const moduleTypeItems = [
       { value: 'All', label: 'All', disabled: false },
-      { value: 'Concept', label: 'Concept', disabled: false },
-      { value: 'Procedure', label: 'Procedure', disabled: false },
-      { value: 'Reference', label: 'Reference', disabled: false }
+      { value: 'CONCEPT', label: 'Concept', disabled: false },
+      { value: 'PROCEDURE', label: 'Procedure', disabled: false },
+      { value: 'REFERENCE', label: 'Reference', disabled: false }
     ]
 
     const sortItems = [
       { value: 'Uploaded date', label: 'Uploaded date', disabled: false },
       { value: 'Title', label: 'Title', disabled: false },
-      { value: 'Product', label: 'Product', disabled: false },
       { value: 'Published date', label: 'Published date', disabled: false },
       { value: 'Updated date', label: 'Updated date', disabled: false },
       { value: 'Module type', label: 'Module type', disabled: false }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleListingServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleListingServlet.java
@@ -53,7 +53,7 @@ public class ModuleListingServlet extends AbstractJsonQueryServlet {
         String[] productVersionIds = request.getParameterValues("productversion");
         String type = paramValue(request, "type");
 
-        if(!newArrayList("Title", "Product", "Published", "Module", "Updated" ).contains(keyParam)) {
+        if(!newArrayList("Title", "Published", "Module", "Updated" ).contains(keyParam)) {
             keyParam = "pant:dateUploaded";
         } else if (keyParam.contains("Title")) {
             keyParam = "jcr:title";
@@ -80,8 +80,8 @@ public class ModuleListingServlet extends AbstractJsonQueryServlet {
         // Condition for module type
         String moduleTypeCondition = "";
         if(!Strings.isNullOrEmpty(type)) {
-            moduleTypeCondition = "AND (draft.[metadata/moduleType] = '" + type + "' " +
-                    "OR release.[metadata/moduleType] = '" + type + "') ";
+            moduleTypeCondition = "AND (draft.[metadata/pant:moduleType] = '" + type + "' " +
+                    "OR release.[metadata/pant:moduleType] = '" + type + "') ";
         }
 
         // product version conditions


### PR DESCRIPTION
I am removing the search sorting by product. What we save in the metadata is just the uuid and we already can filter by product. This also fixes a bug with filtering by moduleType correctly.