### PR TITLE
Asciidoc link/xref dereferencing

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
@@ -25,7 +25,7 @@ public class HtmlModulePostprocessor extends Postprocessor {
     public String process(Document document, String output) {
         return Html.parse(Charsets.UTF_8.name())
                 .andThen(Html.encodeAllImageLocations(module))
-                .andThen(Html.encodeAllXrefs())
+                .andThen(Html.dereferenceAllHyperlinks())
                 .apply(output)
                 .toString();
     }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
@@ -25,7 +25,7 @@ public class HtmlModulePostprocessor extends Postprocessor {
     public String process(Document document, String output) {
         return Html.parse(Charsets.UTF_8.name())
                 .andThen(Html.encodeAllImageLocations(module))
-                .andThen(Html.dereferenceAllHyperlinks())
+                .andThen(Html.dereferenceAllHyperlinks(module.getResourceResolver()))
                 .apply(output)
                 .toString();
     }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/HtmlModulePostprocessor.java
@@ -25,6 +25,7 @@ public class HtmlModulePostprocessor extends Postprocessor {
     public String process(Document document, String output) {
         return Html.parse(Charsets.UTF_8.name())
                 .andThen(Html.encodeAllImageLocations(module))
+                .andThen(Html.encodeAllXrefs())
                 .apply(output)
                 .toString();
     }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/html/Html.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/html/Html.java
@@ -57,6 +57,7 @@ public class Html {
     }
 
     public static Function<Document, Document> dereferenceAllHyperlinks(ResourceResolver resolver) {
+        JcrQueryHelper qh = new JcrQueryHelper(resolver);
         return document -> {
             document.select("a")
                     .forEach(hyperlink -> {
@@ -67,8 +68,7 @@ public class Html {
                                 .map(matcher -> matcher.group())
                                 .forEach(uuid -> {
                                     try {
-                                        new JcrQueryHelper(resolver)
-                                                .query("select * from [pant:module] as module WHERE module.[jcr:uuid] = '" + uuid + "'")
+                                        qh.query("select * from [pant:module] as module WHERE module.[jcr:uuid] = '" + uuid + "'")
                                                 .findFirst()
                                                 .ifPresent(resource -> hyperlink.attr("href", resource.getPath() + ".preview"));
                                     } catch (RepositoryException e) {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/html/Html.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/html/Html.java
@@ -48,6 +48,19 @@ public class Html {
         };
     }
 
+    public static Function<Document, Document> encodeAllXrefs() {
+        return document -> {
+            document.select("a")
+                    .forEach(hyperlink -> {
+                        System.out.println("hyperlink:");
+                        System.out.println(hyperlink);
+                        hyperlink.childNodes().stream()
+                                .forEach(child -> System.out.println(child.nodeName() + " : " + child.outerHtml()));
+                    });
+            return document;
+        };
+    }
+
     /**
      * An extractor function which returns just the body content for the parsed html document.
      * @return An html extactor function.

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/html/HtmlTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/html/HtmlTest.java
@@ -3,11 +3,16 @@ package com.redhat.pantheon.html;
 import com.google.common.base.Charsets;
 import com.redhat.pantheon.conf.GlobalConfig;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -19,6 +24,7 @@ import static org.mockito.Mockito.when;
 class HtmlTest {
 
     final Pattern imageRegEx = Pattern.compile(GlobalConfig.IMAGE_PATH_PREFIX + "/.*");
+    SlingContext sCtx = new SlingContext(ResourceResolverType.JCR_OAK);
 
     @Test
     void parse() {
@@ -60,6 +66,44 @@ class HtmlTest {
         doc.select("img").forEach(image -> {
             assertTrue(image.attr("src").matches(imageRegEx.pattern()));
         });
+    }
+
+    @Test
+    void dereferenceAllHyperlinks() {
+        // Given
+        sCtx.create().resource("/test",
+                "name", "a-name",
+                "jcr:primaryType", "pant:module");
+        sCtx.create().resource("/test/child",
+                "name", "child-name");
+        String resourceUuid = sCtx.resourceResolver()
+                .getResource("/test")
+                .getValueMap()
+                .get("jcr:uuid")
+                .toString();
+
+        String html = "<html>" +
+                "<head><title>This is the head</title></head>" +
+                "<body>This is the body" +
+                "<a href='1234'>vanilla hyperlink</a>" +
+                "<a href='abcd'><!-- " + resourceUuid + " -->link with a valid uuid</a>" +
+                "<a href='xyz'><!-- 123e4567-e89b-12d3-a456-426655440000 -->link with a random uuid</a>" +
+                "</body>" +
+                "</html>";
+
+        // When
+        String transformedHtml = Html.parse(Charsets.UTF_8.name())
+                .andThen(Html.dereferenceAllHyperlinks(sCtx.resourceResolver()))
+                .andThen(doc -> doc.toString())
+                .apply(html);
+
+        // Then
+        Document doc = Jsoup.parse(transformedHtml, "UTF-8");
+        List<Element> elms = doc.select("a").stream().collect(Collectors.toList());
+        assertFalse(elms.isEmpty());
+        assertTrue("1234".equals(elms.get(0).attr("href")));
+        assertFalse("abcd".equals(elms.get(1).attr("href")));
+        assertTrue("xyz".equals(elms.get(2).attr("href")));
     }
 
     @Test


### PR DESCRIPTION
In asciidoc, you can create a hyperlink based off of file paths. However, the link that asciidoctor creates may not reliably point to where the target document ultimately lives in Pantheon.

This PR introduces a mechanism to specify the target module via its Pantheon UUID.

Here is the traditional way of creating an xref in Pantheon:
`<</some/other/doc.adoc,Please click here!>>`

Here is the new mechanism that this PR introduces:
`<</some/other/doc.adoc,pass:[<!-- 123e4567-e89b-12d3-a456-426655440000 -->]Please click here!>>`

When compiled with vanilla asciidoctor, the rendered document will be unaffected by the commented UUID and the link will point to the original author-specific target. When compiled with Pantheon, Pantheon will attempt to resolve the UUID and overwrite the link target with the found module's resource path in Pantheon.

The logic may ultimately need tweaked, but this is a working start.