### PR TITLE
add view_uri to modules in portal

### DIFF
--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -505,11 +505,5 @@
             <version>2.1.4</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -505,5 +505,11 @@
             <version>2.1.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/ModulePostPublishHydraIntegration.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/ModulePostPublishHydraIntegration.java
@@ -49,8 +49,8 @@ public class ModulePostPublishHydraIntegration implements EventProcessingExtensi
     private static final String UUID_FIELD = "jcr:uuid";
     private static final String HYDRA_TOPIC = "VirtualTopic.eng.pantheon2.notifications";
     private static final String ID_KEY = "id";
-    private static final String SOLR_COMMAND_KEY = "solr_command";
-    private static final String SOLR_COMMAND_VALUE = "index";
+    private static final String EVENT_KEY = "event";
+    private static final String EVENT_VALUE = "publish";
     public static final Locale DEFAULT_MODULE_LOCALE = Locale.US;
 
     private SSLContext sslContext;
@@ -102,7 +102,7 @@ public class ModulePostPublishHydraIntegration implements EventProcessingExtensi
         MessageProducer producer = session.createProducer(session.createTopic(HYDRA_TOPIC));
         String moduleUUID = module.getValueMap().get(UUID_FIELD, String.class);
         String msg = "{\"" + ID_KEY + "\":" + "\"" + this.getPantheonHost() + PANTHEON_MODULE_API_PATH + moduleUUID +"\","
-                + "\"" + SOLR_COMMAND_KEY + "\":" + "\"" + SOLR_COMMAND_VALUE + "\"}";
+                + "\"" + EVENT_KEY + "\":" + "\"" + EVENT_VALUE + "\"}";
         producer.send(session.createTextMessage(msg));
         log.info("[" + ModulePostPublishHydraIntegration.class.getSimpleName() + "] message sent: " + session.createTextMessage(msg) );
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
@@ -54,7 +54,6 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
     private final Logger log = LoggerFactory.getLogger(ModuleJsonServlet.class);
 
-
     @Override
     protected String getQuery(SlingHttpServletRequest request) {
 
@@ -104,7 +103,8 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         moduleMap.put("module_url_fragment", resourcePath.substring("/content/repositories/".length(), resourcePath.length()));
 
         // Striping out the jcr: from key name
-        moduleMap.put("module_uuid", moduleMap.remove("jcr:uuid"));
+        String module_uuid = (String) moduleMap.remove("jcr:uuid");
+        moduleMap.put("module_uuid", module_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         moduleMap.put("date_modified", dateModified.toInstant().toString());
@@ -135,6 +135,14 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         String urlFragment = releasedMetadata.get().urlFragment().get() != null ? releasedMetadata.get().urlFragment().get() : "";
         if (!urlFragment.isEmpty()) {
             moduleMap.put("vanity_url_fragment", urlFragment);
+        }
+
+        // Process view_uri
+        if (System.getenv("PORTAL_URL") != null) {
+            //@TODO: map Pantheon locale to view_uri locale
+            String view_uri_locale = "en-us";
+            String view_uri = System.getenv("PORTAL_URL") + "/topics/" + view_uri_locale + "/" + module_uuid;
+            moduleMap.put("view_uri", view_uri);
         }
 
         // remove unnecessary fields from the map

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
@@ -143,9 +143,7 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Process view_uri
         if (System.getenv("PORTAL_URL") != null) {
-            //@TODO: map Pantheon locale to view_uri locale
-            String view_uri_locale = "en-us";
-            String view_uri = System.getenv("PORTAL_URL") + "/topics/" + view_uri_locale + "/" + module_uuid;
+            String view_uri = System.getenv("PORTAL_URL") + "/topics/" + ServletUtils.toLanguageTag(locale) + "/" + module_uuid;
             moduleMap.put("view_uri", view_uri);
         }
 

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -23,7 +21,6 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 
 import com.redhat.pantheon.model.module.Module;
 

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
@@ -1,21 +1,28 @@
 package com.redhat.pantheon.servlet;
 
-import com.redhat.pantheon.model.module.Module;
-import org.apache.sling.api.resource.ModifiableValueMap;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit5.SlingContext;
-import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import javax.jcr.query.Query;
-import java.util.Map;
-
 import static com.google.common.collect.Maps.newHashMap;
 import static com.redhat.pantheon.conf.GlobalConfig.DEFAULT_MODULE_LOCALE;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import javax.jcr.query.Query;
+
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.redhat.pantheon.model.module.Module;
 
 @ExtendWith({SlingContextExtension.class})
 class ModuleJsonServletTest {
@@ -23,6 +30,16 @@ class ModuleJsonServletTest {
     SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
     String testHTML = "<!DOCTYPE html> <html lang=\"en\"> <head><title>test title</title></head> <body " +
             "class=\"article\"><h1>test title</h1> </header> </body> </html>";
+
+    @Rule
+    public final EnvironmentVariables environmentVariables
+      = new EnvironmentVariables();
+
+    @Test
+    public void setEnvironmentVariable() {
+      environmentVariables.set("PORTAL_URL", "https://example.com");
+      assertEquals("https://example.com", System.getenv("PORTAL_URL"));
+    }
 
     @Test
     void getQueryNoParams() {
@@ -109,6 +126,7 @@ class ModuleJsonServletTest {
         assertTrue(moduleMap.containsKey("module_url_fragment"));
         assertTrue(moduleMap.containsKey("revision_id"));
         assertTrue(moduleMap.containsKey("context_url_fragment"));
+        assertTrue(moduleMap.containsKey("view_uri"));
         assertEquals((map.get("message")), "Module Found");
         assertEquals((map.get("status")), SC_OK);
     }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
@@ -1,7 +1,6 @@
 package com.redhat.pantheon.servlet;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static com.redhat.pantheon.conf.GlobalConfig.DEFAULT_MODULE_LOCALE;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -9,18 +8,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Locale;
 import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 
 import com.redhat.pantheon.model.module.Module;
 
@@ -49,7 +52,7 @@ class ModuleJsonServletTest {
         // Given
         ModuleJsonServlet servlet = new ModuleJsonServlet();
         Map<String, Object> map = newHashMap();
-        map.put("locale", DEFAULT_MODULE_LOCALE.toString());
+        map.put("locale", ServletUtils.toLanguageTag(Locale.US));
         map.put("module_id", "jcr:uuid");
         slingContext.request().setParameterMap(map);
 
@@ -120,7 +123,7 @@ class ModuleJsonServletTest {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = "PORTAL_URL", matches = "https://example.com")
+    @EnabledIf("null != systemEnvironment.get('PORTAL_URL')")
     public void onlyRenderViewURIForPORTAL() throws RepositoryException {
         // Given
         slingContext.create()

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/sling/PantheonRepositoryInitializerTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/sling/PantheonRepositoryInitializerTest.java
@@ -6,6 +6,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +20,7 @@ class PantheonRepositoryInitializerTest {
     ServiceResourceResolverProvider serviceResourceResolverProvider;
 
     @Test
+    @EnabledIf("null != systemEnvironment.get('PORTAL_URL') && null != systemEnvision.get('SYNC_SERVICE_URL')")
     void processRepository() throws Exception {
         // Given
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
@@ -42,6 +44,7 @@ class PantheonRepositoryInitializerTest {
     }
 
     @Test
+    @EnabledIf("null != systemEnvironment.get('PORTAL_URL') && null != systemEnvision.get('SYNC_SERVICE_URL')")
     void processRepositoryWithoutSyncservice() throws Exception {
         // Given
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
@@ -56,6 +59,7 @@ class PantheonRepositoryInitializerTest {
     }
 
     @Test
+    @EnabledIf("null != systemEnvironment.get('PORTAL_URL') && null != systemEnvision.get('SYNC_SERVICE_URL')")
     void processRepositoryWithoutPortalUrl() throws Exception {
         // Given
         ResourceResolver resourceResolver = mock(ResourceResolver.class);


### PR DESCRIPTION
This PR introduces two changes
* replace "solr_command: index" with "event:publish" in  messages to Hydra broker
* add "view_uri" in modules api for search integration.