### PR TITLE
enable locale parsing by language tag

### DIFF
--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -277,6 +277,11 @@
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>64.2</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.fusesource.stompjms/stompjms-client -->
         <dependency>
             <groupId>org.fusesource.stompjms</groupId>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/AbstractJsonSingleQueryServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/AbstractJsonSingleQueryServlet.java
@@ -35,7 +35,7 @@ public abstract class AbstractJsonSingleQueryServlet extends SlingSafeMethodsSer
     /**
      * Returns the query to execute. The query may be modified depending on the provided
      * parameters in the request.
-     * @param request The sling servlet request
+     * @param request The servlet request
      * @return A string with the query to execute. The results of this query will be used
      * to render the list of results.
      */
@@ -44,21 +44,24 @@ public abstract class AbstractJsonSingleQueryServlet extends SlingSafeMethodsSer
     /**
      * Provides a way to modify the returned objects based on the found resources.
      * The default implementation just returns the corresponding value map.
+     * @param request The servlet request
      * @param resource The Resource obtained as a result of the query.
      * @return A map with the actual value to be returned to the servlet's caller.
      * @throws RepositoryException
      */
-    protected Map<String, Object> resourceToMap(@NotNull Resource resource) throws RepositoryException {
+    protected Map<String, Object> resourceToMap(@Nonnull SlingHttpServletRequest request,
+                                                @NotNull Resource resource) throws RepositoryException {
         return newHashMap(resource.getValueMap());
     }
 
     /**
      * A post-processor that provides a way to add filter logic for returned objects
      * The default implementation returns true and can be overriden to check for conditions
+     * @param request The servlet request
      * @param resource The Resource obtained as a result of the query.
      * @return Boolean true.
     */
-    protected boolean isValidResource(@Nonnull Resource resource) {
+    protected boolean isValidResource(@Nonnull SlingHttpServletRequest request, @Nonnull Resource resource) {
         return true;
     }
 
@@ -72,9 +75,9 @@ public abstract class AbstractJsonSingleQueryServlet extends SlingSafeMethodsSer
 
             Optional<Resource> firstResource = resultStream.findFirst();
             if(firstResource.isPresent()) {
-                if(isValidResource((firstResource.get()))) {
+                if(isValidResource(request, firstResource.get())) {
                     // Convert the resource to JSON
-                    writeAsJson(response, resourceToMap(firstResource.get()));
+                    writeAsJson(response, resourceToMap(request, firstResource.get()));
                 }
                 else {
                     response.sendError(SC_NOT_FOUND, " Requested resource was invalid.");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleJsonServletTest.java
@@ -8,9 +8,7 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -87,6 +85,7 @@ class ModuleJsonServletTest {
 
         // When
         Map<String, Object> map = servlet.resourceToMap(
+                slingContext.request(),
                 slingContext.resourceResolver().getResource("/content/repositories/repo/module"));
         Map<String, Object> moduleMap = (Map<String, Object>)map.get("module");
 

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ServletUtilsTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ServletUtilsTest.java
@@ -140,13 +140,17 @@ class ServletUtilsTest {
     void paramValueAsLocale() {
         // Given
         lenient().when(request.getParameter(eq("locale"))).thenReturn("en_US");
-        lenient().when(request.getParameter(eq("wrongLocaleFormat"))).thenReturn("12345");
+        lenient().when(request.getParameter(eq("locale2"))).thenReturn("en-us");
+        lenient().when(request.getParameter(eq("locale3"))).thenReturn("fr-fr");
+        lenient().when(request.getParameter(eq("locale4"))).thenReturn("fr_FR");
 
         // When
 
         // Then
         assertEquals(Locale.US, ServletUtils.paramValueAsLocale(request, "locale", null));
-        assertNull(ServletUtils.paramValueAsLocale(request, "wrongLocaleFormat", null));
+        assertEquals(Locale.US, ServletUtils.paramValueAsLocale(request, "locale2", null));
+        assertEquals(Locale.FRANCE, ServletUtils.paramValueAsLocale(request, "locale3", null));
+        assertEquals(Locale.FRANCE, ServletUtils.paramValueAsLocale(request, "locale4", null));
         assertNull(ServletUtils.paramValueAsLocale(request, "nonExistentParameter", null));
         assertEquals(Locale.FRANCE, ServletUtils.paramValueAsLocale(request, "nonExistentParameter", Locale.FRANCE));
     }
@@ -177,5 +181,13 @@ class ServletUtilsTest {
 
         // Then
         assertThrows(RuntimeException.class, () -> ServletUtils.getPathMatcher(pathRegexp, request));
+    }
+
+    @Test
+    void toLanguageTag() {
+        assertEquals("en-us", ServletUtils.toLanguageTag(Locale.US));
+        assertEquals("fr", ServletUtils.toLanguageTag(Locale.FRENCH));
+        assertEquals("ja-jp", ServletUtils.toLanguageTag(Locale.JAPAN));
+        assertEquals("es", ServletUtils.toLanguageTag(new Locale("es")));
     }
 }


### PR DESCRIPTION
Enable the use of BCP47 language tags to identify locales. This means that all servlet parameters accepting locale codes now also accept BCP47 language tags for better compatibility. This also means that whenever the system is returning a locale code, it will preferably return a language tag instead of a Java locale code.