### PR TITLE
bug fix: anonymous module rendering is not working

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/FieldImpl.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/FieldImpl.java
@@ -51,6 +51,11 @@ public class FieldImpl<T> implements Field<T> {
     @Override
     public void set(@Nullable T value) {
         ModifiableValueMap mvm = owner.adaptTo(ModifiableValueMap.class);
+        if(mvm == null) {
+            throw new RuntimeException("Cannot modify resource at " + owner.getPath()
+                    + ": This may be due to denied write  permissions");
+        }
+
         if(value == null) {
             mvm.remove(name);
         }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/ServiceResourceResolverProvider.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/ServiceResourceResolverProvider.java
@@ -1,5 +1,6 @@
 package com.redhat.pantheon.sling;
 
+import com.redhat.pantheon.model.api.SlingModel;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -9,6 +10,11 @@ import org.osgi.service.component.annotations.Reference;
 
 import java.util.function.Consumer;
 
+/**
+ * Component that is able to provide a service-level resource resolver. Service-level resource
+ * resolvers have more rights than the calling user should have, so they should be used carefully
+ * as they might allow operations for users which are not intended.
+ */
 @Component(
         service = ServiceResourceResolverProvider.class
 )

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/ServiceResourceResolverProvider.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/ServiceResourceResolverProvider.java
@@ -1,6 +1,5 @@
 package com.redhat.pantheon.sling;
 
-import com.redhat.pantheon.model.api.SlingModel;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
@@ -53,6 +53,7 @@ class AsciidoctorServiceTest {
         // adapter (mock)
         registerMockAdapter(Module.class, slingContext);
         registerMockAdapter(Content.class, slingContext);
+        registerMockAdapter(ModuleVersion.class, slingContext);
         lenient().when(globalConfig.getTemplateDirectory()).thenReturn(Optional.empty());
         lenient().when(asciidoctorPool.borrowObject())
                 .thenReturn(Asciidoctor.Factory.create());


### PR DESCRIPTION
This change fixes a bug where anonymous users may not generate a module's preview. Since adding automatic metadata extraction from the asciidoc content, the process which writes the metadata to the JCR tree was not given the right permissions. This change ensures that the whole asciidoc generation process uses a service level resource resolver and thus ensure the appropriate write access.