### PR TITLE
Symlinks support

### DIFF
--- a/pantheon-bundle/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
+++ b/pantheon-bundle/src/main/resources/SLING-INF/nodetypes/nodetypes.cnd
@@ -55,9 +55,9 @@
     - sling:resourceType (string) = 'pantheon/productVersion' mandatory autocreated
 
 // Base type for titles
-[pant:title] > nt:unstructured, sling:Resource, mix:referenceable, mix:created, mix:lastModified
-	- sling:resourceType (string) = 'pantheon/title' mandatory autocreated
-    + cachedContent (nt:unstructured) = nt:unstructured mandatory autocreated
+//[pant:title] > nt:unstructured, sling:Resource, mix:referenceable, mix:created, mix:lastModified
+//	- sling:resourceType (string) = 'pantheon/title' mandatory autocreated
+//    + cachedContent (nt:unstructured) = nt:unstructured mandatory autocreated
 
 // Additional types:
 // nt:folder - https://wiki.apache.org/jackrabbit/nt%3Afolder

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessorTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessorTest.java
@@ -1,0 +1,68 @@
+package com.redhat.pantheon.asciidoctor.extension;
+
+import com.redhat.pantheon.model.api.FileResource;
+import com.redhat.pantheon.model.api.SlingModel;
+import com.redhat.pantheon.model.api.SlingModels;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.PreprocessorReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.apache.jackrabbit.JcrConstants.JCR_DATA;
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({SlingContextExtension.class, MockitoExtension.class})
+public class SlingResourceIncludeProcessorTest {
+
+    private final SlingContext slingContext = new SlingContext();
+
+    @Test
+    void resolveWithSymlinks() {
+        //Given
+        slingContext.build()
+                .resource("/irrelevantResource")
+                .resource("/realLocation/testFile",
+                        "name", "dummy",
+                        JCR_PRIMARYTYPE, "nt:file")
+                .resource("/realLocation/testFile/jcr:content",
+                        JCR_DATA, "some included content")
+                .resource("/symlink",
+                        "sling:resourceType", "pant:symlink",
+                        "pant:target", "realLocation")
+                .commit();
+
+        Resource docResource = slingContext.resourceResolver().getResource("/irrelevantResource");
+
+        Document doc = mock(Document.class);
+
+        PreprocessorReader reader = mock(PreprocessorReader.class);
+        when(reader.getFile()).thenReturn("");
+
+        SlingModel model = mock(SlingModel.class);
+        when(model.getProperty(JCR_PRIMARYTYPE, String.class)).thenReturn("nt:file");
+        when(model.adaptTo(FileResource.class)).thenReturn(SlingModels.getModel(
+                slingContext.resourceResolver().getResource("/realLocation/testFile"), FileResource.class));
+
+        slingContext.registerAdapter(Resource.class, SlingModel.class, model);
+
+        //When
+        SlingResourceIncludeProcessor proc = new SlingResourceIncludeProcessor(docResource);
+        proc.process(doc, reader, "/symlink/testFile", null);
+
+        //Then
+        verify(reader).push_include(eq("some included content"), anyString(), anyString(), anyInt(), nullable(Map.class));
+    }
+}

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -91,7 +91,7 @@ parser.add_argument('--repository', '-r', help='The name of the Pantheon reposit
 parser.add_argument('--user', '-u', help='Username for authentication, default \'' + DEFAULT_USER + '\'', default=DEFAULT_USER)
 parser.add_argument('--password', '-p', help='Password for authentication, default \'' + DEFAULT_PASSWORD + '\'. If \'-\' is supplied, the script will prompt for the password.', default=DEFAULT_PASSWORD)
 parser.add_argument('--directory', '-d', help='Directory to upload, default is current working directory. (' + os.getcwd() + ')', default=os.getcwd())
-parser.add_argument('--links', '-l', help='Resolve symlinks when searching for files to upload', action='store_const', const=True)
+parser.add_argument('--links', '-l', help='Resolve symlinks when searching for files to upload', action='store_const', const=DEFAULT_LINKS)
 parser.add_argument('--verbose', '-v', help='Print information that may be helpful for debugging', action='store_const', const=True)
 parser.add_argument('--dry', '-D', help='Dry run; print information about what would be uploaded, but don\'t actually upload', action='store_const', const=True)
 parser.add_argument('--sandbox', '-b', help='Push to the user\'s personal sandbox. This parameter overrides --repository', action='store_const', const=True)


### PR DESCRIPTION
Pantheon 2 and the accompanying uploader now both understand what symlinks are.

So if you have asciidoc with a line like this:
include::recursiveSymlink/recursiveSymlink/recursiveSymlink/include.adoc

...and a directory structure like this:
$ ls -l
recursiveSymlink -> .
include.adoc
master.adoc

...then you can upload via a simple "pantheon push" and both the upload and the preview will complete successfully.
(Previously, the uploader would have churned forever, uploading endless duplicate copies of files, and Pantheon 2 would have ultimately run out of disk space. This no longer happens.)

There is a change in uploader behavior as a result of this PR.
1. You no longer specify 'resources' in your repository. Everything that isn't a module is now a resource and is uploaded as such, to ensure that all symlink-based includes resolve correctly.
2. Removed the option to specify 'titles' because it was a meaningless option that caused confusion.

Note: don't forget to install the new version of pantheon.py before testing this PR.