### PR TITLE
Undefined keywords CCS-3367

### DIFF
--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -559,7 +559,7 @@ class Versions extends Component<IProps, IState> {
             formData.append("productVersion", this.state.versionUUID)
             formData.append("documentUsecase", this.state.usecaseValue)
             formData.append("urlFragment", "/" + this.state.moduleUrl)
-            formData.append("searchKeywords", this.state.keywords)
+            formData.append("searchKeywords", this.state.keywords === undefined ? '' : this.state.keywords)
             // console.log("[metadataPath] ", this.state.metadataPath)
             fetch(this.state.metadataPath + '/metadata', {
                 body: formData,

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -537,7 +537,7 @@ class Versions extends Component<IProps, IState> {
             formData.append('productVersion', this.state.productVersion.uuid)
             formData.append('documentUsecase', this.state.usecaseValue)
             formData.append('urlFragment', '/' + this.state.moduleUrl)
-            formData.append("searchKeywords", this.state.keywords === undefined ? '' : this.state.keywords)
+            formData.append('searchKeywords', this.state.keywords === undefined ? '' : this.state.keywords)
             // console.log('[metadataPath] ', this.state.metadataPath)
             fetch(this.state.metadataPath + '/metadata', {
                 body: formData,


### PR DESCRIPTION
When the user does not specify keywords, they no longer see "undefined" show up in the field on the next page reload.