### PR TITLE
CCS-3392: add logic to parse the module type from an asciidoc property

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/EnumFieldImpl.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/EnumFieldImpl.java
@@ -26,6 +26,10 @@ public class EnumFieldImpl<T extends Enum> extends FieldImpl<T> {
 
     @Override
     public T get() {
-        return (T)Enum.valueOf(getType(), new FieldImpl<>(getName(), String.class, owner).get());
+        FieldImpl<String> fieldImpl = new FieldImpl<>(getName(), String.class, owner);
+        if(fieldImpl.get() == null) {
+            return null;
+        }
+        return (T)Enum.valueOf(getType(), fieldImpl.get());
     }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
@@ -166,8 +166,6 @@ public class ModuleVersionUpload extends AbstractPostOperation {
             Calendar now = Calendar.getInstance();
             metadata.dateModified().set(now);
             metadata.dateUploaded().set(now);
-            metadata.moduleType().set( determineModuleType(module) );
-
             resolver.commit();
 
             if (generateHtml) {
@@ -176,6 +174,13 @@ public class ModuleVersionUpload extends AbstractPostOperation {
                 asciidoctorService.getModuleHtml(draftVersion.get(), module, context, true);
             }
 
+            // Generate a module type based on the file name ONLY after asciidoc generation, so that the
+            // attribute-based logic takes precedence
+            if(metadata.moduleType().get() == null) {
+                metadata.moduleType().set(determineModuleType(module));
+            }
+
+            resolver.commit();
             response.setStatus(responseCode, "");
         } catch (Exception e) {
             throw new RepositoryException("Error uploading a module version", e);

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/SlingModelsTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/SlingModelsTest.java
@@ -104,6 +104,28 @@ class SlingModelsTest {
     }
 
     @Test
+    void nullValueGetters() {
+        // Given
+        Calendar now = Calendar.getInstance();
+        String[] arrayValue = {"A", "B", "C"};
+        sc.build()
+                .resource("/test")
+                .commit();
+
+        // When
+        TestResource model = SlingModels.getModel(sc.resourceResolver(), "/test", TestResource.class);
+
+        // Then
+        assertNull(model.name().get());
+        assertNull(model.dateField().get());
+        assertNull(model.booleanField().get());
+        assertNull(model.intField().get());
+        assertNull(model.longField().get());
+        assertNull(model.stringArrayField().get());
+        assertNull(model.enumField().get());
+    }
+
+    @Test
     void getDeepField() throws Exception {
         // Given
         sc.build()


### PR DESCRIPTION
Pantheon will now detect the `pantheon-module-type` property declared inside a module's content to extract the module type. Valid values for this property are `CONCEPT`, `PROCEDURE`, and `REFERENCE` (all in caps). Any other value will be ignored by Pantheon.

The existing file-name-convention-based logic remains as a backup. This means that pantheon will look at the property first, and if not present, only then will it look at the file name to determine the module type.