### PR TITLE
fix  python exception: 'NoneType' object is not iterable

### DIFF
--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -280,8 +280,9 @@ def listdir_recursive(directory, allFiles):
 
 def readYamlGlob(config, keyword):
     globs = config[keyword] if config is not None and keyword in config else ()
-    for i, val in enumerate(globs):
-        globs[i] = val.replace('*', '[^/]+')
+    if globs is not None:
+        for i, val in enumerate(globs):
+            globs[i] = val.replace('*', '[^/]+')
     return globs
 
 
@@ -297,7 +298,7 @@ def processRegexMatches(files, globs, filetype):
         else:
             subpath = str(f)[len(args.directory) + 1:]
             logger.debug(' Evaluating ' + subpath)
-            for regex in globs:
+            for regex in globs or []:
                 if re.match(regex, subpath):
                     logger.debug(' -- match ' + filetype + ' ' + regex)
                     matches.append(f)


### PR DESCRIPTION
This PR addresses an uploader exception when the Resource section is listed with empty entries.
e.g
cat pantheon2.yml 
```
server: http://localhost:8080
repository: llu
followlinks: true

titles:
modules:
  - docs/cmsfr-release-notes/topics/*.adoc
resources:
  #- titles/**/images/*
```
