### PR TITLE
FCCEUD-26_doc_symlink

### DIFF
--- a/docs
+++ b/docs
@@ -1,0 +1,1 @@
+pantheon-bundle/src/main/resources/SLING-INF/content/docs/


### PR DESCRIPTION
Added a symlink to the docs folder to make it easier for writers to contribute.