### PR TITLE
CCS-3270: File name not displayed instead of the title in search results on uploading the module twice

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
@@ -161,7 +161,10 @@ public class ModuleVersionUpload extends AbstractPostOperation {
 
             Metadata metadata = draftVersion.get()
                     .metadata().getOrCreate();
-            metadata.title().set(moduleName);
+            
+            if(metadata.title().get()==null){
+                metadata.title().set(moduleName);
+            }                    
             metadata.description().set(description);
             Calendar now = Calendar.getInstance();
             metadata.dateModified().set(now);


### PR DESCRIPTION
On uploading the adoc files multiple times, the module title remains the same now.