### PR TITLE
doc is now rebuilt immediately before sending publish event

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PublishDraftVersion.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PublishDraftVersion.java
@@ -18,12 +18,11 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.redhat.pantheon.servlet.ServletUtils.paramValueAsLocale;
@@ -66,9 +65,8 @@ public class PublishDraftVersion extends AbstractPostOperation {
 
 
             //FIXME - this is a hack that needs to be removed when we have the attribute placeholder logic implemented
-            Optional<ModuleVersion> versionToRelease = getModule(request).getReleasedVersion(getLocale(request));
-            Map<String, Object> context = asciidoctorService.buildContextFromRequest(request);
-            asciidoctorService.getModuleHtml(versionToRelease.get(), module, context, true);
+            Optional<ModuleVersion> versionToRelease = module.getReleasedVersion(locale);
+            asciidoctorService.getModuleHtml(versionToRelease.get(), module, new HashMap(), true);
 
 
             events.fireEvent(new ModuleVersionPublishedEvent(moduleLocale.getPath()), 15);

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/PublishDraftVersionTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/PublishDraftVersionTest.java
@@ -1,5 +1,6 @@
 package com.redhat.pantheon.servlet.module;
 
+import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.extension.Events;
 import com.redhat.pantheon.model.module.Module;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -12,6 +13,7 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -25,6 +27,10 @@ import static org.mockito.Mockito.mock;
 class PublishDraftVersionTest {
 
     SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    //FIXME - temporary
+    @Mock
+    AsciidoctorService asciidoctorService;
 
     @Test
     void doRun() throws Exception {
@@ -45,7 +51,9 @@ class PublishDraftVersionTest {
         HtmlResponse postResponse = new HtmlResponse();
         List<Modification> changes = newArrayList();
         slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
-        PublishDraftVersion operation = new PublishDraftVersion(events);
+
+        //FIXME - asciidoctorService parameter is temporary
+        PublishDraftVersion operation = new PublishDraftVersion(events, asciidoctorService);
 
         // When
         operation.doRun(slingContext.request(), postResponse, changes);
@@ -71,7 +79,9 @@ class PublishDraftVersionTest {
         HtmlResponse postResponse = new HtmlResponse();
         List<Modification> changes = newArrayList();
         slingContext.request().setResource( slingContext.resourceResolver().getResource("/module") );
-        PublishDraftVersion operation = new PublishDraftVersion(null);
+
+        //FIXME - asciidoctorService parameter is temporary
+        PublishDraftVersion operation = new PublishDraftVersion(null, asciidoctorService);
 
         // When
         operation.doRun(slingContext.request(), postResponse, changes);


### PR DESCRIPTION
Steps to test:

1. Upload a doc with content similar to this:
```
Pantheon attributes:

showtitle: {showtitle}

pantheonproduct: {pantheonproduct}

pantheonversion: {pantheonversion}

pantheonupdateddate: {pantheonupdateddate}

pantheonpublisheddate: {pantheonpublisheddate}
```
2. Don't assign metadata
3. Preview the doc
4. Assign all necessary metadata
5. Publish the doc
6. View the rendered doc
Old behavior: variables are missing
New behavior: variables are available