### PR TITLE
 vanityURL should be optional

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/versions.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/versions.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`Versions tests should render Versions component 1`] = `
       </FormGroup>
       <FormGroup
         fieldId="url-fragment"
-        isRequired={true}
+        isRequired={false}
         label="Vanity URL fragment"
       >
         <InputGroup>
@@ -271,7 +271,7 @@ exports[`Versions tests should render Versions component 1`] = `
             id="url-fragment"
             isDisabled={false}
             isReadOnly={false}
-            isRequired={true}
+            isRequired={false}
             isValid={true}
             onChange={[Function]}
             placeholder="Enter URL"

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -536,7 +536,7 @@ class Versions extends Component<IProps, IState> {
             const formData = new FormData(event.target.form)
             formData.append('productVersion', this.state.productVersion.uuid)
             formData.append('documentUsecase', this.state.usecaseValue)
-            formData.append('urlFragment', '/' + this.state.moduleUrl)
+            formData.append('urlFragment', this.state.moduleUrl.trim().length > 0 ? '/' + this.state.moduleUrl.trim() : '' )
             formData.append('searchKeywords', this.state.keywords === undefined ? '' : this.state.keywords)
             // console.log('[metadataPath] ', this.state.metadataPath)
             fetch(this.state.metadataPath + '/metadata', {

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -349,14 +349,14 @@ class Versions extends Component<IProps, IState> {
                         </FormGroup>
                         <FormGroup
                             label='Vanity URL fragment'
-                            isRequired={true}
+                            isRequired={false}
                             fieldId='url-fragment'
                         >
                             <InputGroup>
                                 <InputGroupText id='slash' aria-label='/'>
                                     <span>/</span>
                                 </InputGroupText>
-                                <TextInput isRequired={true} id='url-fragment' type='text' placeholder='Enter URL' value={this.state.moduleUrl} onChange={this.handleURLInput} />
+                                <TextInput isRequired={false} id='url-fragment' type='text' placeholder='Enter URL' value={this.state.moduleUrl} onChange={this.handleURLInput} />
                             </InputGroup>
                         </FormGroup>
                         <FormGroup
@@ -524,7 +524,7 @@ class Versions extends Component<IProps, IState> {
         if (this.state.product.value === undefined || this.state.product.value === 'Select a Product' || this.state.product.value === ''
             || this.state.productVersion.uuid === undefined || this.state.productVersion.label === 'Select a Version' || this.state.productVersion.uuid === ''
             || this.state.usecaseValue === undefined || this.state.usecaseValue === 'Select Use Case' || this.state.usecaseValue === ''
-            || this.state.moduleUrl.trim() === '') {
+        ) {
 
             this.setState({ isMissingFields: true })
         } else {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleListingServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleListingServlet.java
@@ -59,7 +59,8 @@ public class ModuleListingServlet extends AbstractJsonQueryServlet {
         String directionParam = paramValue(request, "direction");
         String[] productIds = request.getParameterValues("product");
         String[] productVersionIds = request.getParameterValues("productversion");
-        String type = paramValue(request, "type");        
+        String type = paramValue(request, "type");
+        String urlFragment = paramValue(request, "urlFragment");
 
         if(keyParam==null || keyParam.contains("Uploaded")){
             keyParam = "pant:dateUploaded";
@@ -118,6 +119,13 @@ public class ModuleListingServlet extends AbstractJsonQueryServlet {
         if(!Strings.isNullOrEmpty(type)) {
             StringBuilder moduleTypeCondition = new StringBuilder()
                     .append("*/*/metadata/@pant:moduleType = '" + type + "'");
+            queryFilters.add(moduleTypeCondition);
+        }
+
+        // urlFragment filter
+        if(!Strings.isNullOrEmpty(urlFragment)) {
+            StringBuilder moduleTypeCondition = new StringBuilder()
+                    .append("*/*/metadata/@urlFragment = '" + urlFragment + "'");
             queryFilters.add(moduleTypeCondition);
         }
 
@@ -223,7 +231,7 @@ public class ModuleListingServlet extends AbstractJsonQueryServlet {
         if (!"modules".equals(fragments[2])) {
             m.put("pant:transientSourceName", fragments[3]);
         }
-        
+        m.put("urlFragment", draftMetadata.isPresent() ? draftMetadata.get().urlFragment().get() : releasedMetadata.get().urlFragment().get());
         log.trace(m.toString());
         return m;
     }


### PR DESCRIPTION
This PR addresses a business require change. vanityURL was initially introduced as a required field on medata data. During the MS3 discovery, our business stake holders stated that it should be optional.