### PR TITLE
Unicode file content is now handled properly

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -90,7 +91,10 @@ public class ModuleVersionUpload extends AbstractPostOperation {
         try {
             String locale = ServletUtils.paramValue(request, "locale", GlobalConfig.DEFAULT_MODULE_LOCALE.toString());
             String asciidocContent = ServletUtils.paramValue(request, "asciidoc");
-            asciidocContent = new String(asciidocContent.getBytes(request.getCharacterEncoding()), "utf-8");
+            String encoding = request.getCharacterEncoding();
+            if (encoding != null) {
+                asciidocContent = new String(asciidocContent.getBytes(encoding), StandardCharsets.UTF_8);
+            }
             String path = request.getResource().getPath();
             String moduleName = ResourceUtil.getName(path);
             String description = ServletUtils.paramValue(request, "jcr:description", "");

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleVersionUpload.java
@@ -90,6 +90,7 @@ public class ModuleVersionUpload extends AbstractPostOperation {
         try {
             String locale = ServletUtils.paramValue(request, "locale", GlobalConfig.DEFAULT_MODULE_LOCALE.toString());
             String asciidocContent = ServletUtils.paramValue(request, "asciidoc");
+            asciidocContent = new String(asciidocContent.getBytes(request.getCharacterEncoding()), "utf-8");
             String path = request.getResource().getPath();
             String moduleName = ResourceUtil.getName(path);
             String description = ServletUtils.paramValue(request, "jcr:description", "");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleVersionUploadTest.java
@@ -87,7 +87,7 @@ class ModuleVersionUploadTest {
     }
 
     @Test
-    void createFirstVersionUnicodeFix() throws Exception {
+    void createFirstVersionUnicodeIso() throws Exception {
         // Given
         lenient().when(
                 asciidoctorService.getModuleHtml(
@@ -102,6 +102,36 @@ class ModuleVersionUploadTest {
         slingContext.request().setParameterMap(params);
         slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/proc_module"));
         slingContext.request().setCharacterEncoding(StandardCharsets.ISO_8859_1.toString());
+
+        // when
+        upload.doRun(slingContext.request(), new HtmlResponse(), null);
+
+        // Then
+        Module module =
+                SlingModels.getModel(
+                        slingContext.resourceResolver().getResource("/new/proc_module"),
+                        Module.class);
+        assertEquals("南京防疫现场",
+                module.getDraftContent(LocaleUtils.toLocale("es_ES")).get().asciidocContent().get()
+        );
+    }
+
+    @Test
+    void createFirstVersionUnicodeUtf() throws Exception {
+        // Given
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(ModuleVersion.class), any(Resource.class), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        Map<String, Object> params = newHashMap();
+        params.put("locale", "es_ES");
+        params.put("asciidoc", "南京防疫现场");
+        slingContext.request().setParameterMap(params);
+        slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/proc_module"));
+        slingContext.request().setCharacterEncoding(StandardCharsets.UTF_8.toString());
 
         // when
         upload.doRun(slingContext.request(), new HtmlResponse(), null);

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/ModuleVersionUploadTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -83,6 +84,36 @@ class ModuleVersionUploadTest {
         );
         verify(asciidoctorService).getModuleHtml(
                 any(ModuleVersion.class), any(Resource.class), anyMap(), eq(true));
+    }
+
+    @Test
+    void createFirstVersionUnicodeFix() throws Exception {
+        // Given
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(ModuleVersion.class), any(Resource.class), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        Map<String, Object> params = newHashMap();
+        params.put("locale", "es_ES");
+        params.put("asciidoc", "å\u008D\u0097äº¬é\u0098²ç\u0096«ç\u008E°å\u009Cº");
+        slingContext.request().setParameterMap(params);
+        slingContext.request().setResource(new NonExistingResource(slingContext.resourceResolver(), "/new/proc_module"));
+        slingContext.request().setCharacterEncoding(StandardCharsets.ISO_8859_1.toString());
+
+        // when
+        upload.doRun(slingContext.request(), new HtmlResponse(), null);
+
+        // Then
+        Module module =
+                SlingModels.getModel(
+                        slingContext.resourceResolver().getResource("/new/proc_module"),
+                        Module.class);
+        assertEquals("南京防疫现场",
+                module.getDraftContent(LocaleUtils.toLocale("es_ES")).get().asciidocContent().get()
+        );
     }
 
     @Test


### PR DESCRIPTION
Upload a module with some asian characters to Pantheon and preview it. Prior to this, the encoding was messed up.