### PR TITLE
introduce scripts to run Pantheon locally for development

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,7 +3,7 @@ RUN yum -y install java-1.8.0-openjdk
 
 RUN mkdir -p /opt/sling
 
-COPY ../pantheon-slingstart/target/pantheon-slingstart-*.jar /opt/sling/pantheon.jar
+COPY pantheon-slingstart/target/pantheon-slingstart-*.jar /opt/sling/pantheon.jar
 
 WORKDIR /opt/sling/
 EXPOSE 8080
@@ -12,4 +12,4 @@ EXPOSE 5005
 ENV JAVA_OPTS -Xmx1024m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 ENV SLING_OPS ''
 
-CMD export COMMIT_HASH=$(cat /opt/sling/commit_hash); java $JAVA_OPTS -jar pantheon.jar $SLING_OPTS
+CMD export COMMIT_HASH=$(cat /opt/sling/commit_hash); exec java $JAVA_OPTS -jar pantheon.jar $SLING_OPTS

--- a/recreateSlingContainer.sh
+++ b/recreateSlingContainer.sh
@@ -1,0 +1,26 @@
+#
+# Recreates the Sling container ONLY. It will recompile the bundle and the slingstart
+# module, and will drop the existing container and recreate it.
+# Useful when the recreateSlingPod.sh script has been run beforehand.
+#
+# This script assumes that a database is already running. See the SLING_DB variable below
+# for details.
+#
+echo "Building Pantheon bundle and slingstart..."
+./mvnw clean package -DskipTests
+
+echo "Building Pantheon image..."
+buildah bud --layers -f container/Dockerfile -t pantheon-app .
+
+echo "Stopping existing Pantheon container..."
+podman stop pantheon-app
+
+echo "Removing previosuly stopped Pantheon container..."
+podman rm -f pantheon-app
+
+echo "Running new Pantheon container..."
+# Use this db property to connect to a running replica set pod (see recreateReplicaSetpod.sh)
+SLING_DB='mongodb://localhost:30001,localhost:30002,localhost:30003'
+# Use this db property to connect to a simple DB
+#SLING_DB='mongodb://localhost:27017'
+podman run --pod pantheon -d -e SLING_OPTS="-Dsling.run.modes=oak_mongo -Doak.mongo.uri=$SLING_DB" --name pantheon-app pantheon-app

--- a/recreateSlingPod.sh
+++ b/recreateSlingPod.sh
@@ -1,0 +1,59 @@
+#
+# Recreates a full Sling pod locally for Pantheon development.
+# Creates the database, recompiles and rebuilds the Pantheon bundle and Slingstart.
+# End result is a running Pantheon instance at http://localhost:8080
+#
+# There are two ways to create the database, see the specific lines to uncomment below.
+#
+echo "Removing Pantheon pod..."
+podman pod rm -f pantheon
+
+echo "Creating new Pantheon pod..."
+podman pod create --name pantheon -p 8080 -p 5005 -p 30001 -p 30002 -p 30003
+
+# Uncomment these lines if using a local sling database
+#echo "Running single database container..."
+#SLING_DB='mongodb://localhost:27017'
+#podman run --pod pantheon --name slingmongo -d mongo
+
+# Uncomment these lines if using a replica set. 
+echo "Running database container replica set..."
+SLING_DB='mongodb://localhost:30001,localhost:30002,localhost:30003'
+podman run -d --pod pantheon --name mongo1 mongo:3.6 mongod --port 30001 --replSet mongo-repl-set
+podman run -d --pod pantheon --name mongo2 mongo:3.6 mongod --port 30002 --replSet mongo-repl-set
+podman run -d --pod pantheon --name mongo3 mongo:3.6 mongod --port 30003 --replSet mongo-repl-set
+echo "Waiting for Mongo replica set containers to come up..."
+sleep 5s
+echo "Configuring Mongo replica set..."
+MONGO_COMMANDS=$(cat <<-END
+    db = (new Mongo('localhost:30001')).getDB('test')
+    config = {
+      "_id" : "mongo-repl-set",
+      "members" : [
+        {
+           "_id" : 0,
+           "host" : "localhost:30001"
+        },
+	{
+           "_id" : 1,
+           "host" : "localhost:30002"
+        },
+	{
+           "_id" : 2,
+           "host" : "localhost:30003"
+        }]
+    }
+    rs.initiate(config)
+END
+)
+mongo --port 30001 --eval  "$MONGO_COMMANDS"
+
+echo "Building Pantheon bundle and slingstart..."
+./mvnw clean package -DskipTests
+
+echo "Building Pantheon container image..."
+buildah bud --layers -f container/Dockerfile -t pantheon-app .
+
+echo "Running new Pantheon container..."
+podman run --pod pantheon -d -e SLING_OPTS="-Dsling.run.modes=oak_mongo -Doak.mongo.uri=$SLING_DB" --name pantheon-app pantheon-app
+


### PR DESCRIPTION
This change introduces the following two shell scripts for running  Pantheon in a development machine using Podman.

`recreateSlingPod.sh` - (Re)Creates a full running Pantheon pod, database and all.

This script creates a pod with 3 mongo database containers forming a replica set, and a single container for sling running a build of the existing Pantheon source bundle.

`recreateSlingContainer.sh` - Recreates just the running container for Pantheon.

This script is just a shortcut to just re-create the running pantheon container leaving the database intact (to not lose any data, for example).

This is by no means perfect but it would help for all developers running on a similar environment. Suggestions welcome.