### PR TITLE
 CCS-3494: API endpoint for Hydra to send acknowledgement

### DIFF
--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -288,6 +288,11 @@
             <artifactId>activemq-client</artifactId>
             <version>5.15.11</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.query</artifactId>
+            <version>3.0.0</version>
+        </dependency>
 	    <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_1.1_spec</artifactId>
@@ -461,7 +466,12 @@
             <version>4.5.6</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+            <groupId>org.apache.commons</groupId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/helper/TransformToPojo.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/helper/TransformToPojo.java
@@ -1,0 +1,85 @@
+package com.redhat.pantheon.helper;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Helper methods to unmarshal JSON to corresponding POJO
+ *
+ * @author randalap
+ */
+public class TransformToPojo {
+
+    /**
+     * Marshal from json string to a specific POJO.
+     *
+     * @param <T>   the generic type
+     * @param klass the klass
+     * @param json  the json
+     * @return the type
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T fromJson(final Class klass, final String json) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+
+        return (T) mapper.readValue(new ByteArrayInputStream(json.getBytes()), klass);
+    }
+
+    /**
+     * Unmarshal from JSON  in the reader to the class represnted by Class parameter .
+     *
+     * @param <T>    the type parameter
+     * @param klass  the klass to which JSON has to be unmarshalled
+     * @param reader the reader containing JSON
+     * @return the Class instance containing data from JSON
+     * @throws IOException the io exception
+     */
+    public <T> T fromJson(final Class klass, final Reader reader) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+
+        return (T) mapper.readValue(reader, klass);
+    }
+
+    /**
+     * Unmarshal from json in byte array format to the class represnted by Class parameter .
+     *
+     * @param <T>   the generic type
+     * @param klass the klass
+     * @param json  the json
+     * @return the Class instance containing data from JSON
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T fromJson(final Class klass, final byte[] json) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return (T) mapper.readValue(new ByteArrayInputStream(json), klass);
+    }
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/Acknowledgement.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/Acknowledgement.java
@@ -1,0 +1,151 @@
+
+package com.redhat.pantheon.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "id",
+    "status",
+    "message",
+    "sender"
+})
+public class Acknowledgement {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("message")
+    private String message;
+    @JsonProperty("sender")
+    private String sender;
+
+    /**
+     * 
+     * @return
+     *     The id
+     */
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * 
+     * @param id
+     *     The id
+     */
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Acknowledgement withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * 
+     * @return
+     *     The status
+     */
+    @JsonProperty("status")
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * 
+     * @param status
+     *     The status
+     */
+    @JsonProperty("status")
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Acknowledgement withStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * 
+     * @return
+     *     The message
+     */
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * 
+     * @param message
+     *     The message
+     */
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Acknowledgement withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+     * 
+     * @return
+     *     The sender
+     */
+    @JsonProperty("sender")
+    public String getSender() {
+        return sender;
+    }
+
+    /**
+     * 
+     * @param sender
+     *     The sender
+     */
+    @JsonProperty("sender")
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    public Acknowledgement withSender(String sender) {
+        this.sender = sender;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(id).append(status).append(message).append(sender).toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Acknowledgement) == false) {
+            return false;
+        }
+        Acknowledgement rhs = ((Acknowledgement) other);
+        return new EqualsBuilder().append(id, rhs.id).append(status, rhs.status).append(message, rhs.message).append(sender, rhs.sender).isEquals();
+    }
+
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Module.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Module.java
@@ -2,7 +2,6 @@ package com.redhat.pantheon.model.module;
 
 import com.redhat.pantheon.model.api.WorkspaceChild;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
-import com.redhat.pantheon.model.api.SlingModel;
 
 import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
@@ -101,6 +100,10 @@ public interface Module extends WorkspaceChild {
                 .map(moduleVersion -> moduleVersion.metadata().get());
     }
 
+    default Optional<Status> getAcknowledgementStatus(final Locale locale) {
+        return getReleasedVersion(locale)
+                .map(moduleVersion -> moduleVersion.status().get());
+    }
     /**
      * @param locale The locale to fetch the content instance for.
      * @return The draft metadata for a given locale

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/ModuleVersion.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/ModuleVersion.java
@@ -23,4 +23,5 @@ public interface ModuleVersion extends WorkspaceChild {
     Child<Content> content();
 
     Child<Metadata> metadata();
+    Child<Status> status();
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Status.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Status.java
@@ -1,0 +1,18 @@
+package com.redhat.pantheon.model.module;
+
+import com.redhat.pantheon.model.api.Field;
+import com.redhat.pantheon.model.api.WorkspaceChild;
+
+import javax.inject.Named;
+
+/**
+ * Models an instance of status acknowledgement sent by integrated systems
+ */
+public interface Status extends WorkspaceChild {
+    @Named("pant:status")
+    Field<String> status();
+    @Named("pant:message")
+    Field<String> message();
+    @Named("pant:sender")
+    Field<String> sender();
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/StatusAcknowledgeServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/StatusAcknowledgeServlet.java
@@ -1,0 +1,154 @@
+package com.redhat.pantheon.servlet;
+
+import com.redhat.pantheon.model.Acknowledgement;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.Status;
+import com.redhat.pantheon.helper.TransformToPojo;
+import org.apache.commons.lang3.LocaleUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.apache.sling.query.SlingQuery.$;
+
+/**
+ * Simple servlet that saves the status acknowledgement send by
+ * an endsystem to a status node
+ *
+ * @author A.P.Rajshekhar
+ */
+@Component(
+        service = Servlet.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION +"=Servlet which accepts acknowledgement and status for a published Module",
+                "sling.servlet.methods=" + HttpConstants.METHOD_POST,
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+        }
+)
+@SlingServletPaths(value = "/api/status")
+public class StatusAcknowledgeServlet extends SlingAllMethodsServlet {
+    private final Logger logger = LoggerFactory.getLogger(StatusAcknowledgeServlet.class);
+    @Override
+    protected void doPost(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+
+        Acknowledgement acknowledgement = getAcknowledgementData(request);
+
+        if(isObjectNullOrEmpty(acknowledgement)){
+            getLogger().error("The request did not provide all the fiields "+acknowledgement.toString());
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "All the fields are required");
+            return;
+        }
+        try {
+            Resource resource = getResourceByUuid(acknowledgement.getId(), request);
+            Module module =  resource.adaptTo(Module.class);
+            List<Resource> moduleLocale =  $(module).find("pant:moduleLocale").asList();
+
+            if(!hasLocale(moduleLocale, "en_US")){
+                getLogger().error("The module with id="+acknowledgement.getId()+" does not have en_US locale");
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Locale other than en_US is not supported");
+                return;
+            }
+            processAcknowledgementRequest(acknowledgement, module, moduleLocale);
+
+        } catch (RepositoryException|PersistenceException e) {
+            getLogger().error("The request could not be processed because of error="+e.getMessage(), e);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    /**
+     *  Checks whether all the fields are present
+     * @param acknowledgement the acknowledement object containing request data
+     * @return true if not all fields have data else return false
+     */
+    private boolean isObjectNullOrEmpty(Acknowledgement acknowledgement) {
+        return null == acknowledgement ||
+                Stream.of(acknowledgement.getId(), acknowledgement.getMessage(),
+                        acknowledgement.getSender(),acknowledgement.getStatus())
+                        .anyMatch(Objects::isNull);
+    }
+
+    /**
+     * Process the data in acknowldegment and create node if the module
+     * for which the acknowledgement has data contains supported locale
+     * @param acknowledgement request data
+     * @param module module corresponding to the UUID in the request data
+     * @param moduleLocale list of locales in the module
+     * @throws PersistenceException signals that request data could not be saved
+     */
+    private void processAcknowledgementRequest(Acknowledgement acknowledgement, Module module,
+                                               List<Resource> moduleLocale) throws PersistenceException {
+
+        for (Resource locale : moduleLocale) {
+            //defensive programming: double check that only for en_US locale the status node is created
+            if(locale.getName().equalsIgnoreCase("en_US")) {
+                createStatusNode(locale, module, acknowledgement);
+                break;
+            }
+        }
+    }
+
+    private boolean hasLocale(List<Resource> moduleLocale, String locale) {
+        return moduleLocale.stream().anyMatch(ml -> ml.getName().equalsIgnoreCase(locale));
+    }
+
+    private Acknowledgement getAcknowledgementData(@NotNull SlingHttpServletRequest request) throws IOException {
+        TransformToPojo transformToPojo = new TransformToPojo();
+        return transformToPojo.fromJson(Acknowledgement.class, request.getReader());
+    }
+
+    private void createStatusNode(Resource moduleLocale, Module module, Acknowledgement acknowledgement) throws PersistenceException {
+        Locale locale = LocaleUtils.toLocale(moduleLocale.getName());
+        Status status = module.getReleasedVersion(locale).get().status().getOrCreate();
+        status.status().set(acknowledgement.getStatus());
+        status.message().set(acknowledgement.getMessage());
+        status.sender().set(acknowledgement.getSender());
+        status.getResourceResolver().commit();
+    }
+
+    /**
+     * Retrieves the module corresponding to the uuid
+     * @param uuid id of the module
+     * @param request sling request
+     * @return resource correponding to the uuid
+     * @throws RepositoryException
+     */
+    private Resource getResourceByUuid(String uuid, SlingHttpServletRequest request) throws RepositoryException {
+        Node foundNode = request.getResourceResolver()
+                .adaptTo(Session.class)
+                .getNodeByIdentifier(uuid);
+
+        return request.getResourceResolver()
+                .getResource(foundNode.getPath());
+    }
+
+    /**
+     * Gets logger.
+     *
+     * @return the logger
+     */
+    public Logger getLogger() {
+        return logger;
+    }
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/StatusAcknowledgeServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/StatusAcknowledgeServlet.java
@@ -41,7 +41,7 @@ import static org.apache.sling.query.SlingQuery.$;
 @Component(
         service = Servlet.class,
         property = {
-                Constants.SERVICE_DESCRIPTION +"=Servlet which accepts acknowledgement and status for a published Module",
+                Constants.SERVICE_DESCRIPTION +"=Servlet which accepts acknowledgement and status for publish and unpublish actions for a  Module",
                 "sling.servlet.methods=" + HttpConstants.METHOD_POST,
                 Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
         }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
@@ -30,7 +30,7 @@ public class StatusAcknowledgementServletTest {
     public void setUp(){
         slingContext.create()
                 .resource("/content/repositories/repo/module",
-                        "jcr:primaryType", "pant:module", "pant:hash","3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+                        "jcr:primaryType", "pant:module");
         slingContext.create()
                 .resource("/content/repositories/repo/module/en_US",
                         "jcr:primaryType", "pant:moduleLocale");
@@ -46,8 +46,7 @@ public class StatusAcknowledgementServletTest {
                         "jcr:content", testHTML);
         slingContext.create()
                 .resource("/content/repositories/repo/module/en_US/1/content/cachedHtml",
-                        "jcr:data", testHTML,
-                        "pant:hash", "3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+                        "jcr:data", testHTML);
 
         slingContext.resourceResolver().getResource("/content/repositories/repo/module/en_US").adaptTo(ModifiableValueMap.class)
                 .put("released", slingContext.resourceResolver().getResource("/content/repositories/repo/module/en_US/1").getValueMap()
@@ -103,7 +102,7 @@ public class StatusAcknowledgementServletTest {
 
         slingContext.create()
                 .resource("/content/repositories/repo/module1",
-                        "jcr:primaryType", "pant:module", "pant:hash","3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+                        "jcr:primaryType", "pant:module");
         slingContext.create()
                 .resource("/content/repositories/repo/module1/es_ES",
                         "jcr:primaryType", "pant:moduleLocale");
@@ -119,8 +118,7 @@ public class StatusAcknowledgementServletTest {
                         "jcr:content", testHTML);
         slingContext.create()
                 .resource("/content/repositories/repo/module1/es_ES/1/content/cachedHtml",
-                        "jcr:data", testHTML,
-                        "pant:hash", "3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+                        "jcr:data", testHTML);
 
         slingContext.resourceResolver().getResource("/content/repositories/repo/module1/es_ES").adaptTo(ModifiableValueMap.class)
                 .put("released", slingContext.resourceResolver().getResource("/content/repositories/repo/module1/es_ES/1").getValueMap()

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
@@ -1,0 +1,143 @@
+package com.redhat.pantheon.servlet;
+
+import com.redhat.pantheon.model.api.SlingModels;
+import com.redhat.pantheon.model.module.Module;
+import org.apache.commons.lang3.LocaleUtils;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith({SlingContextExtension.class})
+public class StatusAcknowledgementServletTest {
+    SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+    String testHTML = "<!DOCTYPE html> <html lang=\"en\"> <head><title>test title</title></head> <body " +
+            "class=\"article\"><h1>test title</h1> </header> </body> </html>";
+
+    @BeforeEach
+    public void setUp(){
+        slingContext.create()
+                .resource("/content/repositories/repo/module",
+                        "jcr:primaryType", "pant:module", "pant:hash","3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+        slingContext.create()
+                .resource("/content/repositories/repo/module/en_US",
+                        "jcr:primaryType", "pant:moduleLocale");
+        slingContext.create()
+                .resource("/content/repositories/repo/module/en_US/1",
+                        "jcr:primaryType", "pant:moduleVersion");
+        slingContext.create()
+                .resource("/content/repositories/repo/module/en_US/1/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description");
+        slingContext.create()
+                .resource("/content/repositories/repo/module/en_US/1/content/asciidoc",
+                        "jcr:content", testHTML);
+        slingContext.create()
+                .resource("/content/repositories/repo/module/en_US/1/content/cachedHtml",
+                        "jcr:data", testHTML,
+                        "pant:hash", "3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+
+        slingContext.resourceResolver().getResource("/content/repositories/repo/module/en_US").adaptTo(ModifiableValueMap.class)
+                .put("released", slingContext.resourceResolver().getResource("/content/repositories/repo/module/en_US/1").getValueMap()
+                        .get("jcr:uuid"));
+        registerMockAdapter(Module.class, slingContext);
+    }
+    @Test
+    public void testAddAcknowledgement() throws ServletException, IOException {
+
+        String resourceUuid = slingContext.resourceResolver()
+                .getResource("/content/repositories/repo/module")
+                .getValueMap()
+                .get("jcr:uuid")
+                .toString();
+
+        Charset utf8 = Charset.forName("UTF-8");
+        String data = "{\"id\":\""+resourceUuid+"\",\"status\": \"received\",\"sender\":\"hydra\",\"message\":\"from hydra\"}";
+        slingContext.request().setContent(data.getBytes(utf8));
+        StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
+        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        Assertions.assertEquals(200, slingContext.response().getStatus(), "Status should be 200");
+        Module module =
+                SlingModels.getModel(
+                        slingContext.resourceResolver().getResource("/content/repositories/repo/module"),
+                        Module.class);
+        assertNotNull(module.getReleasedVersion(LocaleUtils.toLocale("en_US")).get().status().get());
+        assertEquals("received", module.getReleasedVersion(LocaleUtils.toLocale("en_US"))
+                .get().status()
+                .get().status().get());
+        assertEquals("from hydra", module.getReleasedVersion(LocaleUtils.toLocale("en_US")).get().status().get().message().get());
+        assertEquals("hydra", module.getReleasedVersion(LocaleUtils.toLocale("en_US")).get().status().get().sender().get());
+    }
+
+    @Test
+    public void testAddAcknowledgementWithoutRequiredFields() throws ServletException, IOException {
+
+        String resourceUuid = slingContext.resourceResolver()
+                .getResource("/content/repositories/repo/module")
+                .getValueMap()
+                .get("jcr:uuid")
+                .toString();
+
+        Charset utf8 = Charset.forName("UTF-8");
+        String data = "{\"id\":\"" + resourceUuid + "\",\"status\": \"received\",\"sender\":\"hydra\"}";
+        slingContext.request().setContent(data.getBytes(utf8));
+        StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
+        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        Assertions.assertEquals( 400, slingContext.response().getStatus(), "Status should be 400");
+    }
+
+    @Test
+    public void testAddAcknowledgementWhenTheLocaleIsNotSupported() throws ServletException, IOException {
+
+        slingContext.create()
+                .resource("/content/repositories/repo/module1",
+                        "jcr:primaryType", "pant:module", "pant:hash","3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+        slingContext.create()
+                .resource("/content/repositories/repo/module1/es_ES",
+                        "jcr:primaryType", "pant:moduleLocale");
+        slingContext.create()
+                .resource("/content/repositories/repo/module1/es_ES/1",
+                        "jcr:primaryType", "pant:moduleVersion");
+        slingContext.create()
+                .resource("/content/repositories/repo/module1/es_ES/1/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description");
+        slingContext.create()
+                .resource("/content/repositories/repo/module1/es_ES/1/content/asciidoc",
+                        "jcr:content", testHTML);
+        slingContext.create()
+                .resource("/content/repositories/repo/module1/es_ES/1/content/cachedHtml",
+                        "jcr:data", testHTML,
+                        "pant:hash", "3815bd73-3d57-41d5-9300-9726fdd0f4b7");
+
+        slingContext.resourceResolver().getResource("/content/repositories/repo/module1/es_ES").adaptTo(ModifiableValueMap.class)
+                .put("released", slingContext.resourceResolver().getResource("/content/repositories/repo/module1/es_ES/1").getValueMap()
+                        .get("jcr:uuid"));
+        registerMockAdapter(Module.class, slingContext);
+        String resourceUuid = slingContext.resourceResolver()
+                .getResource("/content/repositories/repo/module1")
+                .getValueMap()
+                .get("jcr:uuid")
+                .toString();
+
+        Charset utf8 = Charset.forName("UTF-8");
+        String data = "{\"id\":\""+resourceUuid+"\",\"status\": \"received\",\"sender\":\"hydra\",\"message\":\"from hydra\"}";
+        slingContext.request().setContent(data.getBytes(utf8));
+        StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
+        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        Assertions.assertEquals(400, slingContext.response().getStatus(), "Status should be 400");
+
+    }
+}


### PR DESCRIPTION
This PR is for CCS-3494. It implements the following functionality:

- To make the API consistent the endpoint is be /api/status.
- The request would be POST and no path param would be needed.
- The request body would be: {"id":"$UUID", "status": "$status", "message": "Some helpful information", "sender": "hydra" }
- Saving of acknowledgement is supported, ATM, only for en_US locale
- The acknowledgement is saved as a node named status that would be sibling to metadata node.
- If a new request comes with same UUID, the existing node data would be updated.