### PR TITLE
Drupal module apis

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Module.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/Module.java
@@ -1,10 +1,12 @@
 package com.redhat.pantheon.model.module;
 
+import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.WorkspaceChild;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
 import com.redhat.pantheon.model.api.SlingModel;
 
 import javax.annotation.Nonnull;
+import javax.inject.Named;
 import javax.jcr.RepositoryException;
 import java.util.Locale;
 import java.util.Optional;
@@ -37,6 +39,9 @@ import static java.util.Optional.ofNullable;
  */
 @JcrPrimaryType("pant:module")
 public interface Module extends WorkspaceChild {
+
+    @Named("jcr:uuid")
+    Field<String> uuid();
 
     default ModuleLocale getModuleLocale(Locale locale) {
         return getChild(locale.toString(), ModuleLocale.class);

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/AbstractJsonSingleQueryServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/AbstractJsonSingleQueryServlet.java
@@ -80,10 +80,10 @@ public abstract class AbstractJsonSingleQueryServlet extends SlingSafeMethodsSer
                     writeAsJson(response, resourceToMap(request, firstResource.get()));
                 }
                 else {
-                    response.sendError(SC_NOT_FOUND, " Requested resource was invalid.");
+                    response.sendError(SC_NOT_FOUND, "Requested resource was invalid.");
                 }
             } else {
-                response.sendError(SC_NOT_FOUND, " Requested content not found.");
+                response.sendError(SC_NOT_FOUND, "Requested content not found.");
             }
 
         } catch (RepositoryException e) {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ModuleJsonServlet.java
@@ -2,6 +2,8 @@ package com.redhat.pantheon.servlet;
 
 import com.google.common.base.Charsets;
 import com.redhat.pantheon.html.Html;
+import com.redhat.pantheon.model.ProductVersion;
+import com.redhat.pantheon.model.api.Reference;
 import com.redhat.pantheon.model.module.Content;
 import com.redhat.pantheon.model.module.Metadata;
 import com.redhat.pantheon.model.module.Module;
@@ -18,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -124,21 +127,21 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         // Fields that are part of the spec and yet to be implemented
         moduleMap.put("context_url_fragment", "");
         moduleMap.put("context_id", "");
-        moduleMap.put(PRODUCT_NAME, "");
-        moduleMap.put(PRODUCT_VERSION, "");
+
+
         moduleMap.put(VANITY_URL_FRAGMENT, "");
         moduleMap.put(SEARCH_KEYWORDS, new String[] {});
         moduleMap.put(VIEW_URI, "");
 
         // Process productVersion from metadata
-        String productVersion = releasedMetadata.get().productVersion().get() != null ? releasedMetadata.get().productVersion().getReference().name().get() : "";
-        if (!productVersion.isEmpty()) {
-            try {
-                moduleMap.put(PRODUCT_VERSION, productVersion);
-                moduleMap.put(PRODUCT_NAME, releasedMetadata.get().productVersion().getReference().getParent().getParent().getValueMap().get("name", String.class));
-            }  catch (RepositoryException e) {
-                log.error(e.getMessage());
-            }
+        // Making these arrays - in the future, we will have multi-product, so get the API right the first time
+        moduleMap.put(PRODUCT_NAME, new String[] {});
+        moduleMap.put(PRODUCT_VERSION, new String[] {});
+        Reference<ProductVersion> pvr = releasedMetadata.get().productVersion();
+        if (pvr != null) {
+            ProductVersion pv = pvr.getReference();
+            moduleMap.put(PRODUCT_VERSION, new String[] { pv.name().get() });
+            moduleMap.put(PRODUCT_NAME, new String[] { pv.getProduct().name().get() });
         }
 
         // Process url_fragment from metadata

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/IncludedInAssembliesServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/IncludedInAssembliesServlet.java
@@ -32,13 +32,13 @@ import static com.redhat.pantheon.servlet.ServletUtils.writeAsJson;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 /**
- * Get operation to render a Released Module's related module list in JSON format.
+ * Get operation to render a Released Module's related assembly list in JSON format.
  * Only two parameters are expected in the Get request:
  * 1. locale - Optional; indicates the locale that the module content is in, defaulted to en-US
  * 2. module_id - indicates the uuid string which uniquely identifies a module
  *
- * The url to GET a request from the server is /api/module/related
- * Example: <server_url>/api/module/related?locale=en-us&module_id=xyz
+ * The url to GET a request from the server is /api/module/assemblies
+ * Example: <server_url>/api/module/assemblies?locale=en-us&module_id=xyz
  * The said url is accessible outside of the system without any authentication.
  *
  * @author Ben Radey
@@ -46,13 +46,13 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 @Component(
         service = Servlet.class,
         property = {
-                Constants.SERVICE_DESCRIPTION + "=Servlet to facilitate GET operation which accepts locale and module uuid to output module relationships",
+                Constants.SERVICE_DESCRIPTION + "=Servlet to facilitate GET operation which accepts locale and module uuid to output module assemblies",
                 Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
         })
-@SlingServletPaths(value = "/api/module/related")
-public class RelatedModuleServlet extends SlingSafeMethodsServlet {
+@SlingServletPaths(value = "/api/module/assemblies")
+public class IncludedInAssembliesServlet extends SlingSafeMethodsServlet {
 
-    private final Logger log = LoggerFactory.getLogger(RelatedModuleServlet.class);
+    private final Logger log = LoggerFactory.getLogger(IncludedInAssembliesServlet.class);
 
     @Override
     protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
@@ -74,18 +74,18 @@ public class RelatedModuleServlet extends SlingSafeMethodsServlet {
 
             resultStream = queryHelper.query("select * from [pant:module] as module", 3, 0);
 
-            List<Map> related = new ArrayList<>();
+            List<Map> assemblies = new ArrayList<>();
             resultStream.map(r -> r.adaptTo(Module.class))
                     .forEach(module -> {
                             Map<String, String> m = new HashMap<>();
                             m.put("title", module.getModuleLocale(locale).getVersion("1").metadata().get().title().get());
-                            m.put("url", "https://www.redhat.com/moduleplaceholder");
+                            m.put("url", "https://www.redhat.com/assemblyplaceholder");
                             m.put("uuid", module.uuid().get());
-                        related.add(m);
+                        assemblies.add(m);
             });
 
             Map result = new HashMap();
-            result.put("related", related);
+            result.put("assemblies", assemblies);
 
             writeAsJson(response, result);
         } catch (RepositoryException e) {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
@@ -1,4 +1,4 @@
-package com.redhat.pantheon.servlet;
+package com.redhat.pantheon.servlet.module;
 
 import com.google.common.base.Charsets;
 import com.redhat.pantheon.html.Html;
@@ -8,6 +8,8 @@ import com.redhat.pantheon.model.module.Content;
 import com.redhat.pantheon.model.module.Metadata;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleVersion;
+import com.redhat.pantheon.servlet.AbstractJsonSingleQueryServlet;
+import com.redhat.pantheon.servlet.ServletUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
@@ -64,14 +66,12 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
 
     @Override
     protected String getQuery(SlingHttpServletRequest request) {
-
         // Get the query parameter(s)
         String uuidParam = paramValue(request, "module_id", "");
 
-        StringBuilder query = new StringBuilder("select * from [pant:module]")
-                .append(" as module WHERE ")
-                // look for a specific uuid for module
-                .append("module.[jcr:uuid] = '" + uuidParam + "'");
+        StringBuilder query = new StringBuilder("select * from [pant:module] as module WHERE module.[jcr:uuid] = '")
+                .append(uuidParam)
+                .append("'");
         return query.toString();
     }
 
@@ -137,9 +137,8 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         // Making these arrays - in the future, we will have multi-product, so get the API right the first time
         moduleMap.put(PRODUCT_NAME, new String[] {});
         moduleMap.put(PRODUCT_VERSION, new String[] {});
-        Reference<ProductVersion> pvr = releasedMetadata.get().productVersion();
-        if (pvr != null) {
-            ProductVersion pv = pvr.getReference();
+        ProductVersion pv = releasedMetadata.get().productVersion().getReference();
+        if (pv != null) {
             moduleMap.put(PRODUCT_VERSION, new String[] { pv.name().get() });
             moduleMap.put(PRODUCT_NAME, new String[] { pv.getProduct().name().get() });
         }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
@@ -23,8 +23,10 @@ import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +59,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
     public static final String PRODUCT_VERSION = "product_version";
     public static final String PRODUCT_NAME = "product_name";
+    public static final String PRODUCT_LINK = "product_link";
     public static final String VANITY_URL_FRAGMENT = "vanity_url_fragment";
     public static final String SEARCH_KEYWORDS = "search_keywords";
     public static final String VIEW_URI = "view_uri";
@@ -135,12 +138,15 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Process productVersion from metadata
         // Making these arrays - in the future, we will have multi-product, so get the API right the first time
-        moduleMap.put(PRODUCT_NAME, new String[] {});
-        moduleMap.put(PRODUCT_VERSION, new String[] {});
+        List<Map> productList = new ArrayList<>();
+        moduleMap.put("products", productList);
         ProductVersion pv = releasedMetadata.get().productVersion().getReference();
         if (pv != null) {
-            moduleMap.put(PRODUCT_VERSION, new String[] { pv.name().get() });
-            moduleMap.put(PRODUCT_NAME, new String[] { pv.getProduct().name().get() });
+            Map<String, String> productMap = new HashMap<>();
+            productList.add(productMap);
+            productMap.put(PRODUCT_VERSION, pv.name().get());
+            productMap.put(PRODUCT_NAME, pv.getProduct().name().get());
+            productMap.put(PRODUCT_LINK, "https://www.redhat.com/productlinkplaceholder");
         }
 
         // Process url_fragment from metadata

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
@@ -1,4 +1,4 @@
-package com.redhat.pantheon.servlet;
+package com.redhat.pantheon.servlet.module;
 
 import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.conf.GlobalConfig;
@@ -9,6 +9,7 @@ import com.redhat.pantheon.model.module.Metadata;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleVersion;
 import com.redhat.pantheon.model.module.ModuleType;
+import com.redhat.pantheon.servlet.ServletUtils;
 import com.redhat.pantheon.sling.ServiceResourceResolverProvider;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -19,7 +20,6 @@ import org.apache.sling.servlets.post.AbstractPostOperation;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostOperation;
 import org.apache.sling.servlets.post.PostResponse;
-import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/RelatedModuleServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/RelatedModuleServlet.java
@@ -1,0 +1,95 @@
+package com.redhat.pantheon.servlet.module;
+
+import com.redhat.pantheon.jcr.JcrQueryHelper;
+import com.redhat.pantheon.model.module.Module;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.redhat.pantheon.conf.GlobalConfig.DEFAULT_MODULE_LOCALE;
+import static com.redhat.pantheon.servlet.ServletUtils.paramValue;
+import static com.redhat.pantheon.servlet.ServletUtils.paramValueAsLocale;
+import static com.redhat.pantheon.servlet.ServletUtils.writeAsJson;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+/**
+ * Get operation to render a Released Module's related module list in JSON format.
+ * Only two parameters are expected in the Get request:
+ * 1. locale - Optional; indicates the locale that the module content is in, defaulted to en-US
+ * 2. module_id - indicates the uuid string which uniquely identifies a module
+ *
+ * The url to GET a request from the server is /api/module/related
+ * Example: <server_url>/api/module/related?locale=en-us&module_id=xyz
+ * The said url is accessible outside of the system without any authentication.
+ *
+ * @author Ben Radey
+ */
+@Component(
+        service = Servlet.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=Servlet to facilitate GET operation which accepts locale and module uuid to output module relationships",
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+        })
+@SlingServletPaths(value = "/api/module/related")
+public class RelatedModuleServlet extends SlingSafeMethodsServlet {
+
+    private final Logger log = LoggerFactory.getLogger(RelatedModuleServlet.class);
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+        Locale locale = paramValueAsLocale(request, "locale", DEFAULT_MODULE_LOCALE);
+        String uuidParam = paramValue(request, "module_id", "");
+
+        StringBuilder query = new StringBuilder("select * from [pant:module] as module WHERE module.[jcr:uuid] = '")
+                .append(uuidParam)
+                .append("'");
+
+        JcrQueryHelper queryHelper = new JcrQueryHelper(request.getResourceResolver());
+        try {
+            Stream<Resource> resultStream = queryHelper.query(query.toString());
+
+            Optional<Resource> firstResource = resultStream.findFirst();
+            if(!firstResource.isPresent()) {
+                response.sendError(SC_NOT_FOUND, "Requested content not found.");
+            }
+
+            resultStream = queryHelper.query("select * from [pant:module] as module", 3, 0);
+
+            List<Map> related = new ArrayList<>();
+            resultStream.map(r -> r.adaptTo(Module.class))
+                    .forEach(module -> {
+                            Map<String, String> m = new HashMap<>();
+                            m.put("title", module.getModuleLocale(locale).getVersion("1").metadata().get().title().get());
+                            m.put("url", "https://www.redhat.com");
+                            m.put("uuid", module.uuid().get());
+                        related.add(m);
+            });
+
+            Map result = new HashMap();
+            result.put("related", related);
+
+            writeAsJson(response, result);
+        } catch (RepositoryException e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
@@ -102,12 +102,11 @@ class ModuleJsonServletTest {
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("module"));
         assertTrue(moduleMap.containsKey("module_uuid"));
-        assertTrue(moduleMap.containsKey("product_version"));
+        assertTrue(moduleMap.containsKey("products"));
         assertTrue(moduleMap.containsKey("description"));
         assertTrue(moduleMap.containsKey("locale"));
         assertTrue(moduleMap.containsKey("title"));
         assertTrue(moduleMap.containsKey("body"));
-        assertTrue(moduleMap.containsKey("product_name"));
         assertTrue(moduleMap.containsKey("content_type"));
         assertTrue(moduleMap.containsKey("date_modified"));
         assertTrue(moduleMap.containsKey("date_published"));

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
@@ -1,4 +1,4 @@
-package com.redhat.pantheon.servlet;
+package com.redhat.pantheon.servlet.module;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
@@ -14,6 +14,8 @@ import java.util.Map;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 
+import com.redhat.pantheon.servlet.ServletUtils;
+import com.redhat.pantheon.servlet.module.ModuleJsonServlet;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -1,10 +1,11 @@
-package com.redhat.pantheon.servlet;
+package com.redhat.pantheon.servlet.module;
 
 import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.model.api.SlingModels;
 import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleVersion;
 import com.redhat.pantheon.model.module.ModuleType;
+import com.redhat.pantheon.servlet.module.ModuleVersionUpload;
 import com.redhat.pantheon.sling.ServiceResourceResolverProvider;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;


### PR DESCRIPTION
Fixing up the existing module info servlet, and adding a dummy related module servlet, in order to unblock Drupal development. Since the related module servlet is a placeholder, no unit tests have been written. We can handle that once we implement the real logic.