### PR TITLE
Image symlinks

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assets/ImageServletFilter.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assets/ImageServletFilter.java
@@ -1,6 +1,10 @@
 package com.redhat.pantheon.servlet.assets;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.servlets.annotations.SlingServletFilter;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 
 import javax.servlet.Filter;
@@ -52,7 +56,29 @@ public class ImageServletFilter implements Filter {
         String assetId = pathMatcher.group("assetId");
 
         String imagePath = new String(Base64.getUrlDecoder().decode(assetId));
-        request.getRequestDispatcher(imagePath)
+        StringBuilder realPath = new StringBuilder(imagePath);
+
+        //Find out if this resolves by itself already.
+        ResourceResolver resolver = ((SlingHttpServletRequest) request).getResourceResolver();
+        Resource res = resolver.resolve(imagePath);
+        if (res == null || "sling:nonexisting".equals(res.getResourceType())) {
+            //Because of symlinks, we need to resolve imagePath manually.
+            String[] parts = imagePath.split("/");
+            realPath.setLength(0);
+            for (String part : parts) {
+                if (part.isEmpty()) {
+                    continue;
+                }
+                realPath.append("/").append(part);
+                Resource resource = resolver.resolve(realPath.toString());
+                if ("pantheon/symlink".equals(resource.getResourceType())) {
+                    realPath.setLength(realPath.length() - part.length());
+                    realPath.append(resource.getValueMap().get("pant:target", String.class));
+                }
+            }
+        }
+
+        request.getRequestDispatcher(realPath.toString())
             .forward(request, response);
     }
 


### PR DESCRIPTION
This tweaks our image servlet to be able to serve images that are resolved using symlinks.

I.e. if you have the following structure:
/images/whatever.png
/modules/mod.adoc
/modules/imglink -> ../images

And this in your mod.adoc:
image::imglink/whatever.png[]

Then this should now resolve correctly.