### PR TITLE
Assembly paging prototype

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/SlingResourceIncludeProcessor.java
@@ -77,7 +77,8 @@ public class SlingResourceIncludeProcessor extends IncludeProcessor {
             log.warn("Could not find include for {}", target);
         }
 
-        reader.push_include(content, target, target, 1, attributes);
+        String includedFilePath = includeResource != null ? includeResource.getPath() : target;
+        reader.push_include(content, includedFilePath, includedFilePath, 1, attributes);
     }
 
     private Resource resolveWithSymlinks(String path, Resource pathParent) {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/jcr/JcrQueryHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/jcr/JcrQueryHelper.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Lists;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
@@ -26,6 +28,18 @@ public class JcrQueryHelper {
 
     public JcrQueryHelper(ResourceResolver resourceResolver) {
         this.resourceResolver = resourceResolver;
+    }
+
+    public Resource findById(String id) throws RepositoryException {
+        Session session = resourceResolver.adaptTo(Session.class);
+        Node node;
+        try {
+            node = session.getNodeByIdentifier(id);
+        } catch (ItemNotFoundException infe) {
+            return null;
+        }
+        // Transform to a sling resource
+        return resourceResolver.getResource(node.getPath());
     }
 
     /**

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyPageRenderingServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyPageRenderingServlet.java
@@ -1,0 +1,74 @@
+package com.redhat.pantheon.servlet.assembly;
+
+import com.google.common.base.Charsets;
+import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.html.Html;
+import com.redhat.pantheon.jcr.JcrQueryHelper;
+import com.redhat.pantheon.model.api.SlingModels;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.ModuleVersion;
+import com.redhat.pantheon.servlet.ServletUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.jetbrains.annotations.NotNull;
+import org.jsoup.nodes.Document;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+
+import javax.jcr.RepositoryException;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Optional;
+
+/**
+ * @author Carlos Munoz
+ */
+@Component(
+        service = Servlet.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=Renders an assembly page in html",
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+        })
+@SlingServletPaths(value = "/api/assembly")
+public class AssemblyPageRenderingServlet extends SlingSafeMethodsServlet {
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+        String assemblyId = ServletUtils.paramValue(request, "id");
+        Long pageNum = ServletUtils.paramValueAsLong(request, "page", 1L);
+
+        try {
+            // First get the assembly
+            // Since there are no assemblies yet, we will get modules
+            JcrQueryHelper helper = new JcrQueryHelper(request.getResourceResolver());
+            Resource assemblyResource = helper.findById(assemblyId);
+            Module assembly = SlingModels.getModel(assemblyResource, Module.class);
+
+            // Get the page content
+            // Split by sections with class 'sect1' as they seem to be the top level sections
+            // Assuming latest draft or released version, and only in English for now
+            Optional<ModuleVersion> versionOpt = assembly.getReleasedVersion(GlobalConfig.DEFAULT_MODULE_LOCALE);
+            ModuleVersion version = versionOpt.orElse( assembly.getDraftVersion(GlobalConfig.DEFAULT_MODULE_LOCALE).get() );
+            String fullHtmlContent = version.content().get().cachedHtml().get().data().get();
+            // Now split it into the right page
+            String pageHtml = Html.parse(Charsets.UTF_8.name())
+                    .andThen(Document::body)
+                    .andThen(element -> element.select("section.sect1"))
+                    .andThen(elements -> elements.listIterator(pageNum.intValue()-1).next())
+                    .andThen(element -> element.outerHtml())
+                    .apply(fullHtmlContent);
+
+            // Render the page as html
+            response.setContentType("text/html");
+            Writer w = response.getWriter();
+            w.write(pageHtml);
+        } catch (RepositoryException e) {
+            throw new ServletException(e);
+        }
+    }
+}


### PR DESCRIPTION
Create a prototype for a potential assembly paging mechanism.
Using the module infrastructure this revision creates a new api endpoint at 
`/api/assembly?id=<identifier>&page=<page num>`

where `id` is a module id (eventually an assembly id) and `page num` is the a page to fetch from the assembly (it's optional and defaults to the first page)

The  api returns the html for a single page, determined by `section` tags. These tags are the result of asciidoctor's processing and they are top level tags in the body of the assembly's html.

This PR also fixes a bug in the `SlingResourceIncludeProcessor` which causes invalid includes for includes at a third level or below.