### PR TITLE
Custom MockSlingHttpServletRequest for the HttpServlet methods not supported by MockSlingHttpServletRequest

### DIFF
--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/MockSlingHttpServletRequest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/MockSlingHttpServletRequest.java
@@ -1,0 +1,22 @@
+package com.redhat.pantheon.servlet;
+
+import org.apache.sling.api.resource.ResourceResolver;
+
+import java.security.Principal;
+
+public class MockSlingHttpServletRequest extends org.apache.sling.servlethelpers.MockSlingHttpServletRequest{
+    public MockSlingHttpServletRequest(ResourceResolver resourceResolver) {
+        super(resourceResolver);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return new Principal() {
+            @Override
+            public String getName() {
+                return "demo";
+            }
+        };
+    }
+
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/StatusAcknowledgementServletTest.java
@@ -63,10 +63,13 @@ public class StatusAcknowledgementServletTest {
                 .toString();
 
         Charset utf8 = Charset.forName("UTF-8");
+
         String data = "{\"id\":\""+resourceUuid+"\",\"status\": \"received\",\"sender\":\"hydra\",\"message\":\"from hydra\"}";
-        slingContext.request().setContent(data.getBytes(utf8));
+        //slingContext.request().setContent(data.getBytes(utf8));
+        MockSlingHttpServletRequest mockSlingHttpServletRequest = new MockSlingHttpServletRequest(slingContext.resourceResolver());
+        mockSlingHttpServletRequest.setContent(data.getBytes(utf8));
         StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
-        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        statusAcknowledgeServlet.doPost(mockSlingHttpServletRequest, slingContext.response());
         Assertions.assertEquals(200, slingContext.response().getStatus(), "Status should be 200");
         Module module =
                 SlingModels.getModel(
@@ -91,9 +94,10 @@ public class StatusAcknowledgementServletTest {
 
         Charset utf8 = Charset.forName("UTF-8");
         String data = "{\"id\":\"" + resourceUuid + "\",\"status\": \"received\",\"sender\":\"hydra\"}";
-        slingContext.request().setContent(data.getBytes(utf8));
+        MockSlingHttpServletRequest mockSlingHttpServletRequest = new MockSlingHttpServletRequest(slingContext.resourceResolver());
+        mockSlingHttpServletRequest.setContent(data.getBytes(utf8));
         StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
-        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        statusAcknowledgeServlet.doPost(mockSlingHttpServletRequest, slingContext.response());
         Assertions.assertEquals( 400, slingContext.response().getStatus(), "Status should be 400");
     }
 
@@ -132,9 +136,10 @@ public class StatusAcknowledgementServletTest {
 
         Charset utf8 = Charset.forName("UTF-8");
         String data = "{\"id\":\""+resourceUuid+"\",\"status\": \"received\",\"sender\":\"hydra\",\"message\":\"from hydra\"}";
-        slingContext.request().setContent(data.getBytes(utf8));
+        MockSlingHttpServletRequest mockSlingHttpServletRequest = new MockSlingHttpServletRequest(slingContext.resourceResolver());
+        mockSlingHttpServletRequest.setContent(data.getBytes(utf8));
         StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
-        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        statusAcknowledgeServlet.doPost(mockSlingHttpServletRequest, slingContext.response());
         Assertions.assertEquals(400, slingContext.response().getStatus(), "Status should be 400");
 
     }
@@ -174,9 +179,10 @@ public class StatusAcknowledgementServletTest {
 
         Charset utf8 = Charset.forName("UTF-8");
         String data = "{\"id\":\""+resourceUuid+"\",\"status\": \"received\",\"sender\":\"hydra\",\"message\":\"from hydra\"}";
-        slingContext.request().setContent(data.getBytes(utf8));
+        MockSlingHttpServletRequest mockSlingHttpServletRequest = new MockSlingHttpServletRequest(slingContext.resourceResolver());
+        mockSlingHttpServletRequest.setContent(data.getBytes(utf8));
         StatusAcknowledgeServlet statusAcknowledgeServlet = new StatusAcknowledgeServlet();
-        statusAcknowledgeServlet.doPost(slingContext.request(), slingContext.response());
+        statusAcknowledgeServlet.doPost(mockSlingHttpServletRequest, slingContext.response());
         Assertions.assertEquals(200, slingContext.response().getStatus(), "Status should be 200");
         Module module =
                 SlingModels.getModel(


### PR DESCRIPTION
MockSlingHttpServletRequest does not support the some of the methods HttpServletRequest including but not limited to getUserPrincipal. This PR extends the existing MockSlingHttpServletRequest to override those methods. In this PR I have overridden getUserPrincipal. 

@xdavidson this would fix the test failures you are experiencing for https://github.com/redhataccess/pantheon/pull/271