### PR TITLE
update ACL to allow ackStatus node to be created for existing modules

### DIFF
--- a/pantheon-slingstart/src/main/provisioning/pantheon.txt
+++ b/pantheon-slingstart/src/main/provisioning/pantheon.txt
@@ -67,5 +67,10 @@
     end
 
     set ACL for pantheon-statusProvider
-        allow jcr:write on /content/repositories restriction(rep:ntNames,pant:acknowledgment)
+        allow rep:write on /content/repositories restriction(rep:glob,*)
+
+        deny jcr:modifyProperties on /content/repositories restriction(rep:ntNames,nt:resource)
+        deny jcr:modifyProperties on /content/repositories restriction(rep:ntNames,pant:symlink)
+        deny jcr:modifyProperties on /content/repositories restriction(rep:ntNames,pant:moduleLocale)
+        deny jcr:modifyProperties on /content/repositories restriction(rep:ntNames,pant:moduleVersion)
     end


### PR DESCRIPTION
This PR updates the ACL so that if ackStatus node is not prepopulated, the pantheon-statusProvider user can create it.