### PR TITLE
resolves CORS issue using Filter

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/CorsEnablingFilter.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/CorsEnablingFilter.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
     })
 @SlingServletFilter(scope = {SlingServletFilterScope.REQUEST},
                     pattern = "/api/.*",
-                    methods = {"GET","HEAD", "OPTIONS"})
+                    methods = {"GET","HEAD","OPTIONS"})
 public class CorsEnablingFilter implements Filter {
     
     public static final String DOMAIN_ALLOWED = ".redhat.com";

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/CorsEnablingFilter.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/CorsEnablingFilter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -31,36 +32,29 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.servlets.annotations.SlingServletFilter;
 import org.apache.sling.servlets.annotations.SlingServletFilterScope;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
-//import org.apache.felix.scr.annotations.Component;
-//import org.apache.felix.scr.annotations.Properties;
-//import org.apache.felix.scr.annotations.Property;
-//import org.apache.felix.scr.annotations.Service;
-//import org.apache.felix.scr.annotations.sling.SlingFilter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Simple Filter
+ * A Filter that Enables CORS Support
  * 
- * Annotations below are short version of:
- * 
- * @Component
- * @Service(Filter.class)
- * @Properties({
- *     @Property(name="service.description", value="A Simple Filter"),
- *     @Property(name="service.vendor", value="The Apache Software Foundation"),
- *     @Property(name="sling.filter.scope", value="REQUEST"),
- *     @Property(name="service.ranking", intValue=1)
- * })
  */
-@Component
+@Component(
+    service = Filter.class,
+    property = {
+            Constants.SERVICE_DESCRIPTION + "=Filter to enable CORS support",
+            Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+    })
 @SlingServletFilter(scope = {SlingServletFilterScope.REQUEST},
-                    methods = {"GET","HEAD"})
-public class SimpleFilter implements Filter {
+                    pattern = "/api/.*",
+                    methods = {"GET","HEAD", "OPTIONS"})
+public class CorsEnablingFilter implements Filter {
     
     public static final String DOMAIN_ALLOWED = ".redhat.com";
-    private final Logger log = LoggerFactory.getLogger(SimpleFilter.class);
+    private final Logger log = LoggerFactory.getLogger(CorsEnablingFilter.class);
 
     public void init(FilterConfig filterConfig) throws ServletException {
     }
@@ -71,7 +65,7 @@ public class SimpleFilter implements Filter {
         final SlingHttpServletResponse response = (SlingHttpServletResponse)res;
         String origin = request.getHeader("Origin");
         if (origin != null) {
-            if (origin.contains(DOMAIN_ALLOWED)) {
+            if (origin.endsWith(DOMAIN_ALLOWED)) {
                  response.addHeader("Access-control-Allow-Origin", origin);
                  response.addHeader("Access-control-Allow-Methods", "GET, HEAD, OPTIONS");
             }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/SimpleFilter.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/SimpleFilter.java
@@ -27,6 +27,11 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.servlets.annotations.SlingServletFilter;
+import org.apache.sling.servlets.annotations.SlingServletFilterScope;
+import org.osgi.service.component.annotations.Component;
 //import org.apache.felix.scr.annotations.Component;
 //import org.apache.felix.scr.annotations.Properties;
 //import org.apache.felix.scr.annotations.Property;
@@ -49,22 +54,30 @@ import org.slf4j.LoggerFactory;
  *     @Property(name="service.ranking", intValue=1)
  * })
  */
-//@SlingFilter(order=1, description="A Simple Filter")
-//@Property(name="service.vendor", value="The Apache Software Foundation")
+@Component
+@SlingServletFilter(scope = {SlingServletFilterScope.REQUEST},
+                    methods = {"GET","HEAD"})
 public class SimpleFilter implements Filter {
     
+    public static final String DOMAIN_ALLOWED = ".redhat.com";
     private final Logger log = LoggerFactory.getLogger(SimpleFilter.class);
 
     public void init(FilterConfig filterConfig) throws ServletException {
     }
 
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+    public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain) throws IOException,
             ServletException {
-        log.info("filter invoked - start");
+        final SlingHttpServletRequest request = (SlingHttpServletRequest)req;
+        final SlingHttpServletResponse response = (SlingHttpServletResponse)res;
+        String origin = request.getHeader("Origin");
+        if (origin != null) {
+            if (origin.contains(DOMAIN_ALLOWED)) {
+                 response.addHeader("Access-control-Allow-Origin", origin);
+                 response.addHeader("Access-control-Allow-Methods", "GET, HEAD, OPTIONS");
+            }
+        }
         chain.doFilter(request, response);
-        log.info("filter invoked - end");
     }
-
     public void destroy() {
     }
 

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
@@ -2,21 +2,15 @@ package com.redhat.pantheon.servlet;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import java.io.PrintWriter;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.testing.mock.sling.MockSling;
@@ -58,13 +52,13 @@ public class CorsEnablingFilterTest {
 
         // simulate query string
         request.setQueryString("locale=en-us&module_id=123-456-789");
-        
+
         // set current resource
         request.setResource(resourceResolver.getResource("/api/module"));
-        
+
         // set method
         request.setMethod(HttpConstants.METHOD_GET);
-        
+
         // set headers
         request.addHeader("Origin", "https://www.redhat.com");
 

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
@@ -1,0 +1,86 @@
+package com.redhat.pantheon.servlet;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.PrintWriter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.testing.mock.sling.MockSling;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({SlingContextExtension.class})
+public class CorsEnablingFilterTest {
+
+    private SlingHttpServletResponse response = null;
+    private FilterChain chain = null;
+    SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Create mocks for required variables
+        response = mock(SlingHttpServletResponse.class);
+        chain = mock(FilterChain.class);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Clear variables during teardown
+        // Not actually necessary as they get re-initialized in setUp
+        response = null;
+        chain = null;
+    }
+
+    @Test
+    public void testDoFilter() throws Exception {
+        // prepare sling request
+        ResourceResolver resourceResolver = MockSling.newResourceResolver(slingContext.bundleContext());
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(resourceResolver);
+
+        // simulate query string
+        request.setQueryString("locale=en-us&module_id=123-456-789");
+        
+        // set current resource
+        request.setResource(resourceResolver.getResource("/api/module"));
+        
+        // set method
+        request.setMethod(HttpConstants.METHOD_GET);
+        
+        // set headers
+        request.addHeader("Origin", "https://www.redhat.com");
+
+        // Mock out the respone's PrintWriter
+        when(response.getWriter()).thenReturn(mock(PrintWriter.class));
+
+        CorsEnablingFilter filter = new CorsEnablingFilter();
+
+        // Execute the method with the mocks we want to test
+        filter.doFilter(request, response, chain);
+
+        // Verify that chain.doFilter() was called
+        verify(chain).doFilter(request, response);
+
+        // Verify that a string were written to the response
+        // (This filter writes HTML comments above and below the chain.doFilter(..)
+        verify(response.getWriter(), times(1)).write(anyString());
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
@@ -69,5 +69,7 @@ public class CorsEnablingFilterTest {
 
         // Verify that chain.doFilter() was called
         verify(chain).doFilter(request, response);
+        verify(response).addHeader("Access-control-Allow-Origin", "https://www.redhat.com");
+        verify(response).addHeader("Access-control-Allow-Methods", "GET, HEAD, OPTIONS");
     }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/CorsEnablingFilterTest.java
@@ -62,9 +62,6 @@ public class CorsEnablingFilterTest {
         // set headers
         request.addHeader("Origin", "https://www.redhat.com");
 
-        // Mock out the respone's PrintWriter
-        when(response.getWriter()).thenReturn(mock(PrintWriter.class));
-
         CorsEnablingFilter filter = new CorsEnablingFilter();
 
         // Execute the method with the mocks we want to test
@@ -72,9 +69,5 @@ public class CorsEnablingFilterTest {
 
         // Verify that chain.doFilter() was called
         verify(chain).doFilter(request, response);
-
-        // Verify that a string were written to the response
-        // (This filter writes HTML comments above and below the chain.doFilter(..)
-        verify(response.getWriter(), times(1)).write(anyString());
     }
 }


### PR DESCRIPTION
This PR addresses the CORS issue CP raised against our API calls. It uses a SlingServletFilter to allow *.redhat.com to consume our api on GET/HEAD requests