### PR TITLE
add a more compact null-safe way to traverse jcr structures using models

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/Child.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/Child.java
@@ -40,6 +40,9 @@ public interface Child<T extends SlingModel> extends Supplier<T> {
      * @return An optional indicating the result of the operation. If the operation
      * returns null, or if the value of this child was not present in the first place,
      * this returns an empty Optional
+     * @deprecated Use {@link com.redhat.pantheon.model.api.util.SafeResourceTraversal#start(SlingModel)}
+     * for safe resource traversals
      */
+    @Deprecated
     <R> Optional<R> map(Function<? super T, ? extends R> func);
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ChildImpl.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ChildImpl.java
@@ -77,7 +77,10 @@ public class ChildImpl<T extends SlingModel> implements Child<T> {
      * @return An optional indicating the result of the operation. If the operation
      * returns null, or if the value of this child was not present in the first place,
      * this returns an empty Optional
+     * @deprecated Use {@link com.redhat.pantheon.model.api.util.SafeResourceTraversal#start(SlingModel)}
+     * for safe resource traversals
      */
+    @Deprecated
     @Override
     public <R> Optional<R> map(Function<? super T, ? extends R> func) {
         T value = get();

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/SafeResourceTraversal.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/SafeResourceTraversal.java
@@ -1,0 +1,91 @@
+package com.redhat.pantheon.model.api.util;
+
+import com.redhat.pantheon.model.api.Child;
+import com.redhat.pantheon.model.api.Field;
+import com.redhat.pantheon.model.api.SlingModel;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * Utility class which offers a null-safe way to traverse deep {@link SlingModel}
+ * structures. Traversals represent paths across multiple nodes ending in deeper
+ * child nodes, or properties. If any of the intermediary nodes is not present, the whole traversal
+ * will still conclude, with a final result of null.<br/>
+ * <br/>
+ * To use it, invoke the {@link SafeResourceTraversal#start(SlingModel)} method with a
+ * model to be traversed. From there on, the whole structure may be traversed all the
+ * way down to specific fields.
+ *
+ * @author Carlos Munoz
+ */
+public class SafeResourceTraversal<T extends SlingModel> implements Supplier<T> {
+
+    private static final SafeResourceTraversal<?> EMPTY = new SafeResourceTraversal<>(null);
+
+    private final Optional<T> currentResource;
+
+    private SafeResourceTraversal(T resource) {
+        this.currentResource = ofNullable(resource);
+    }
+
+    /**
+     * Starts a safe traversal.
+     * @param model The {@link SlingModel} to traverse.
+     * @param <U>
+     * @return A traversal object starting from the given {@link SlingModel}. If the model
+     * is null, traversals will still conclude but will always yield null results.
+     */
+    public static final <U extends SlingModel> SafeResourceTraversal<U> start(@Nullable U model) {
+        return new SafeResourceTraversal<>(model);
+    }
+
+    /**
+     * Traverses the current node in the traversal, down to one of its children.
+     * @param childAccessor A function that returns a {@link Child} of the current resource.
+     * @param <U>
+     * @return A resource traversal at the child accessed via the child accessor.
+     */
+    public <U extends SlingModel> SafeResourceTraversal<U> traverse(Function<? super T, Child<U>> childAccessor) {
+        if(currentResource.isPresent()) {
+            Child<U> nextTraversalChild = childAccessor.apply(currentResource.get());
+            return new SafeResourceTraversal<>(nextTraversalChild.get());
+        }
+        return (SafeResourceTraversal<U>) EMPTY;
+    }
+
+    /**
+     * Traverses to a field in the current traversed node. This represents and end
+     * to the traversal as there is nothing to traverse from a field.
+     * @param fieldAccessor A function that returns a {@link Field} from the current resource.
+     * @param <P>
+     * @return An optional containing the value of the field. If the field is not present, or if
+     * any of the intermediary nodes in the traversal was not present, this optional is empty.
+     */
+    public <P> Optional<P> field(Function<? super T, Field<P>> fieldAccessor) {
+        if(currentResource.isPresent()) {
+            Field<P> field = fieldAccessor.apply(currentResource.get());
+            return ofNullable(field.get());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return The current resource in the traversal. May be null if the resource does not exist.
+     */
+    @Override
+    public T get() {
+        return currentResource.get();
+    }
+
+    /**
+     * @return True, if the current resource in the traversal exists, false otherwise.
+     */
+    public boolean isPresent() {
+        return currentResource.isPresent();
+    }
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/SafeResourceTraversal.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/SafeResourceTraversal.java
@@ -36,11 +36,11 @@ public class SafeResourceTraversal<T extends SlingModel> implements Supplier<T> 
     /**
      * Starts a safe traversal.
      * @param model The {@link SlingModel} to traverse.
-     * @param <U>
+     * @param <M> The Sling Model type to start the traversal
      * @return A traversal object starting from the given {@link SlingModel}. If the model
      * is null, traversals will still conclude but will always yield null results.
      */
-    public static final <U extends SlingModel> SafeResourceTraversal<U> start(@Nullable U model) {
+    public static final <M extends SlingModel> SafeResourceTraversal<M> start(@Nullable M model) {
         return new SafeResourceTraversal<>(model);
     }
 
@@ -62,13 +62,13 @@ public class SafeResourceTraversal<T extends SlingModel> implements Supplier<T> 
      * Traverses to a field in the current traversed node. This represents and end
      * to the traversal as there is nothing to traverse from a field.
      * @param fieldAccessor A function that returns a {@link Field} from the current resource.
-     * @param <P>
+     * @param <F> The type of the field to access
      * @return An optional containing the value of the field. If the field is not present, or if
      * any of the intermediary nodes in the traversal was not present, this optional is empty.
      */
-    public <P> Optional<P> field(Function<? super T, Field<P>> fieldAccessor) {
+    public <F> Optional<F> field(Function<? super T, Field<F>> fieldAccessor) {
         if(currentResource.isPresent()) {
-            Field<P> field = fieldAccessor.apply(currentResource.get());
+            Field<F> field = fieldAccessor.apply(currentResource.get());
             return ofNullable(field.get());
         }
         return Optional.empty();

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/util/SafeResourceTraversalTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/util/SafeResourceTraversalTest.java
@@ -1,0 +1,79 @@
+package com.redhat.pantheon.model.api.util;
+
+import com.redhat.pantheon.model.api.Child;
+import com.redhat.pantheon.model.api.Field;
+import com.redhat.pantheon.model.api.SlingModel;
+import com.redhat.pantheon.model.api.SlingModels;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.redhat.pantheon.model.api.util.SafeResourceTraversal.start;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * @author Carlos Munoz
+ */
+@ExtendWith({SlingContextExtension.class})
+class SafeResourceTraversalTest {
+
+    SlingContext sc = new SlingContext();
+
+    @Test
+    void traverse() {
+        // Given
+        sc.build()
+                .resource("/level1/level2/level3",
+                        "name", "A NAME")
+                .commit();
+        Level1 startModel = SlingModels.getModel(sc.resourceResolver().getResource("/level1"), Level1.class);
+
+        // When
+
+        // Then
+        assertEquals("A NAME", start(startModel)
+                .traverse(Level1::level2)
+                .traverse(Level2::level3)
+                .field(Level3::name)
+                .get());
+    }
+
+    @Test
+    void incompleteTraversal() {
+        // Given
+        sc.build()
+                .resource("/level1")
+                .commit();
+        Level1 startModel = SlingModels.getModel(sc.resourceResolver().getResource("/level1"), Level1.class);
+
+        // When
+
+        // Then
+        assertFalse(start(startModel)
+                .traverse(Level1::level2)
+                .isPresent());
+        assertFalse(start(startModel)
+                .traverse(Level1::level2)
+                .traverse(Level2::level3)
+                .isPresent());
+        assertFalse(start(startModel)
+                .traverse(Level1::level2)
+                .traverse(Level2::level3)
+                .field(Level3::name)
+                .isPresent());
+    }
+
+    interface Level1 extends SlingModel {
+        Child<Level2> level2();
+    }
+
+    interface Level2 extends SlingModel {
+        Child<Level3> level3();
+    }
+
+    interface Level3 extends SlingModel {
+        Field<String> name();
+    }
+}


### PR DESCRIPTION
Add a more compact null-safe way to traverse jcr structures using models.
This revision deprecates the existing `Child.map` method and adds a similar but more compact way to do complex JCR structure traversals and avoid `null` elements in the path. 

See the unit tests for the way to use it.