### PR TITLE
 CCS-3635:  Update travis build to work with karaf distribution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sling-org-apache-sling-karaf-distribution"]
+	path = sling-org-apache-sling-karaf-distribution
+	url = https://github.com/apache/sling-org-apache-sling-karaf-distribution.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sling-org-apache-sling-karaf-distribution"]
-	path = sling-org-apache-sling-karaf-distribution
-	url = https://github.com/apache/sling-org-apache-sling-karaf-distribution.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
 
       install:
         - curl -o $HOME/.m2/settings.xml     https://raw.githubusercontent.com/aprajshekhar/maven-settings/master/settings.xml
-        - mvn dependency:go-offline
       # build specific modules and only log errors
       script: ./mvnw clean install -q -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist 
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       install:
         - curl -o $HOME/.m2/settings.xml     https://raw.githubusercontent.com/aprajshekhar/maven-settings/master/settings.xml
       # build specific modules and only log errors
-      script: ./mvnw clean install -q -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist 
+      script: ./mvnw clean install -q -pl sling-org-apache-sling-karaf-distribution,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
       after_success:
       # Move the code coverage results to codecov
       - bash <(curl -s https://codecov.io/bash) -cF java

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ matrix:
     - language: java
       jdk: openjdk8
       install: true
-      script: ./mvnw clean install
+      # build specific modules and only log errors
+      script: ./mvnw clean install -q -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist 
       after_success:
       # Move the code coverage results to codecov
       - bash <(curl -s https://codecov.io/bash) -cF java

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       install:
         - curl -o $HOME/.m2/settings.xml     https://raw.githubusercontent.com/aprajshekhar/maven-settings/master/settings.xml
       # build specific modules and only log errors
-      script: ./mvnw clean install -q -pl sling-org-apache-sling-karaf-distribution,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
+      script: ./mvnw clean  install -q  -e -pl sling-org-apache-sling-karaf-distribution,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
       after_success:
       # Move the code coverage results to codecov
       - bash <(curl -s https://codecov.io/bash) -cF java

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ matrix:
   include:
     - language: java
       jdk: openjdk8
-      install: true
+
+      cache:
+        directories:
+          - $HOME/.m2
+
+      install:
+        - curl -o $HOME/.m2/settings.xml     https://raw.githubusercontent.com/aprajshekhar/maven-settings/master/settings.xml
+        - mvn dependency:go-offline
       # build specific modules and only log errors
       script: ./mvnw clean install -q -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist 
       after_success:
       # Move the code coverage results to codecov
       - bash <(curl -s https://codecov.io/bash) -cF java
       - bash <(curl -s https://codecov.io/bash) -cF javascript
-      cache:
-        directories:
-        - $HOME/.m2
 
     - language: go
       sudo: false

--- a/pantheon-karaf-feature/pom.xml
+++ b/pantheon-karaf-feature/pom.xml
@@ -31,14 +31,8 @@
   <artifactId>pantheon-karaf-feature</artifactId>
   <packaging>feature</packaging>
 
-  <name>Apache Sling - Karaf Features</name>
-  <description>Apache Sling Features for provisioning with Apache Karaf</description>
-
-  <scm>
-    <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-karaf-features.git</connection>
-    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-karaf-features.git</developerConnection>
-    <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-karaf-features.git</url>
-  </scm>
+  <name>Pantheon - Karaf Features</name>
+  <description>Pantheon Features for provisioning with Apache Karaf</description>
 
   <build>
     <plugins>
@@ -60,11 +54,35 @@
   </build>
 
   <dependencies>
+    <!-- The apache.org.sling.karaf-configs dependency needs to be built 
+    Using jitpack.io for the same
+    -->
     <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.karaf-configs</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
-    </dependency>
+	    <groupId>com.github.apache</groupId>
+	    <artifactId>sling-org-apache-sling-karaf-configs</artifactId>
+	    <version>master-SNAPSHOT</version>
+	</dependency>
   </dependencies>
-
+<repositories>
+  <!-- The repository for karf-configs -->
+  <repository>
+    <id>jitpack.io</id>
+    <url>https://jitpack.io</url>
+  </repository>
+  <!-- The repository for maven-karaf-plugin -->
+  <repository>
+    <id>maven2-central-repository</id>
+    <name>Maven2 central Repository</name>
+    <url>https://repo1.maven.org/maven2</url>
+    <layout>default</layout>
+    <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+    </releases>
+    <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+    </snapshots>
+</repository>
+</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
         <module>pantheon-bundle</module>
         <module>pantheon-karaf-feature</module>
         <module>pantheon-karaf-dist</module>
-        <module>sling-org-apache-sling-karaf-distribution</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>pantheon-bundle</module>
         <module>pantheon-karaf-feature</module>
         <module>pantheon-karaf-dist</module>
+        <module>sling-org-apache-sling-karaf-distribution</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This PR is to update travis build to work with karaf distribution. The changes are:

- Added JitPack based dependency and repository to pantheon-karaf-feature to resolve org.apache.sling.karaf-configs
- Added maven central repository to resolve maven-karf-plugin dependency
- Updated travis.yaml to output only error logs. This is to mitigate log exceeded maximum lines error.