### PR TITLE
 CCS-3635:  Update travis build to work with karaf distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,19 @@ matrix:
   include:
     - language: java
       jdk: openjdk8
-      install: true
-      script: ./mvnw clean install
+
+      cache:
+        directories:
+          - $HOME/.m2
+
+      install:
+        - curl -o $HOME/.m2/settings.xml     https://raw.githubusercontent.com/aprajshekhar/maven-settings/master/settings.xml
+      # build specific modules and only log errors
+      script: ./mvnw clean  install -q  -e -pl  pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
       after_success:
       # Move the code coverage results to codecov
       - bash <(curl -s https://codecov.io/bash) -cF java
       - bash <(curl -s https://codecov.io/bash) -cF javascript
-      cache:
-        directories:
-        - $HOME/.m2
 
     - language: go
       sudo: false

--- a/pantheon-karaf-feature/pom.xml
+++ b/pantheon-karaf-feature/pom.xml
@@ -31,14 +31,8 @@
   <artifactId>pantheon-karaf-feature</artifactId>
   <packaging>feature</packaging>
 
-  <name>Apache Sling - Karaf Features</name>
-  <description>Apache Sling Features for provisioning with Apache Karaf</description>
-
-  <scm>
-    <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-karaf-features.git</connection>
-    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-karaf-features.git</developerConnection>
-    <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-karaf-features.git</url>
-  </scm>
+  <name>Pantheon - Karaf Features</name>
+  <description>Pantheon Features for provisioning with Apache Karaf</description>
 
   <build>
     <plugins>
@@ -60,11 +54,35 @@
   </build>
 
   <dependencies>
+    <!-- The apache.org.sling.karaf-configs dependency needs to be built 
+    Using jitpack.io for the same
+    -->
     <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.karaf-configs</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
-    </dependency>
+	    <groupId>com.github.apache</groupId>
+	    <artifactId>sling-org-apache-sling-karaf-configs</artifactId>
+	    <version>master-SNAPSHOT</version>
+	</dependency>
   </dependencies>
-
+<repositories>
+  <!-- The repository for karf-configs -->
+  <repository>
+    <id>jitpack.io</id>
+    <url>https://jitpack.io</url>
+  </repository>
+  <!-- The repository for maven-karaf-plugin -->
+  <repository>
+    <id>maven2-central-repository</id>
+    <name>Maven2 central Repository</name>
+    <url>https://repo1.maven.org/maven2</url>
+    <layout>default</layout>
+    <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+    </releases>
+    <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+    </snapshots>
+</repository>
+</repositories>
 </project>

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -20,7 +20,7 @@ cd $PANTHEON_CODEBASE
 
 set -e
 # build the distribution
-./mvnw clean install -DskipTests -U -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist 
+./mvnw clean install  -U -pl pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
 # extract the distribution
 tar -xvf pantheon-karaf-dist/target/pantheon-karaf-dist-1.0-SNAPSHOT.tar.gz -C pantheon-karaf-dist/target/ 
 # run the distribution


### PR DESCRIPTION
This PR is to update travis build to work with karaf distribution. The changes are:

-  Added JitPack based dependency to pantheon-karaf-feature to resolve org.apache.sling.karaf-configs
-  Added maven central repository to resolve maven-karf-plugin dependency
-  Udated travis-yaml to use customized settings.xml
-  Updated travis.yaml to output only error logs. This is to mitigate log exceeded maximum lines error.
