### PR TITLE
uploader validation QA comments

### DIFF
--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -13,6 +13,7 @@ import requests
 import yaml
 from requests import Response
 from datetime import datetime
+from time import time
 
 
 DEFAULT_SERVER = 'http://localhost:8080'
@@ -300,7 +301,7 @@ def process_workspace(path):
     logger.debug('url: %s', url)
     workspace = {}
     workspace['jcr:primaryType'] = 'pant:workspace'
-    workspace['jcr:lastModified'] = datetime.now().strftime("%Y-%m-%dT%H:%m:%S") #SimpleDateFormat:yyyy-MM-dd'T'HH:mm:ss
+    workspace['jcr:lastModified'] = datetime.now().utcnow().strftime("%Y-%m-%dT%H:%m:%S") #SimpleDateFormat:yyyy-MM-dd'T'HH:mm:ss
     # Process variants. variants is a list of dictionaries
 
     data = {}

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -305,7 +305,6 @@ def process_workspace(path):
     # Process variants. variants is a list of dictionaries
 
     data = {}
-    cannonicalPresent = False
     if variants:
         validateVariants()
         for variant in variants:
@@ -319,7 +318,6 @@ def process_workspace(path):
                     module_variants['pant:attributesFilePath'] = value
                 if key.lower() == 'canonical':
                     module_variants['pant:canonical'] = value
-                    cannonicalPresent = 'true'
             if len(variants) == 1:
                 module_variants['pant:canonical'] = 'true'
             if 'pant:name' in module_variants:

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -13,8 +13,6 @@ import requests
 import yaml
 from requests import Response
 from datetime import datetime
-from time import time
-
 
 DEFAULT_SERVER = 'http://localhost:8080'
 DEFAULT_USER = 'author'

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -491,6 +491,7 @@ if len(config.keys()) > 0 and 'repository' in config:
         _warn(f'{leftoverFiles} additional files detected but not uploaded. Only files specified in '
               + CONFIG_FILE
               + ' are handled for upload.')
+
 else:
     sys.exit('Modules and resources not found, please check yaml syntax')
 print('Finished!')


### PR DESCRIPTION
QA Comments for CCS 3600 fixes:
1.) When 'canonical' is missing from pantheon2.yml default value of canonical is set as True in the backend
2.) When value of canonical is blank in pantheon2.yml, 500 server error is displayed. Proper error message should be displayed instead
3.)  Value of canonical is saved as True in the backed, when its value is undefined in panthon2.yml
4.) Also observed that, when we try to upload the same repo twice, the last modified time is not updated.
5.) If a user does not update the pantheon2.yml (keeps it the previous format)  then he should get an error for missing fields which is not the case currently