### PR TITLE
sling servlet suffix utility

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -10,6 +10,7 @@ import com.redhat.pantheon.model.module.ModuleVariant;
 import com.redhat.pantheon.model.module.ModuleVersion;
 import com.redhat.pantheon.servlet.AbstractJsonSingleQueryServlet;
 import com.redhat.pantheon.servlet.ServletUtils;
+import com.redhat.pantheon.servlet.util.SlingPathSuffix;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
@@ -47,11 +48,12 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
     private final Logger log = LoggerFactory.getLogger(ModuleJsonServlet.class);
 
+    private final SlingPathSuffix suffix = new SlingPathSuffix("/{variantUuid}");
+
     @Override
     protected String getQuery(SlingHttpServletRequest request) {
         // Get the query parameter(s)
-
-        String uuid = request.getRequestPathInfo().getSuffix().substring(1);
+        String uuid = suffix.getParam("variantUuid", request);
         StringBuilder query = new StringBuilder("select * from [pant:moduleVariant] as moduleVariant WHERE moduleVariant.[jcr:uuid] = '")
                 .append(uuid)
                 .append("'");

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
@@ -36,9 +36,14 @@ public class SlingPathSuffix {
     private Map<String, String> parameterMap;
     private final Pattern pattern;
 
-    public SlingPathSuffix(final String parameterTemplate) {
+    /**
+     * Constructs a new {@link SlingPathSuffix}
+     * @param suffixTemplate The expected suffix template. See the class javadoc for the
+     *                       specifics of this template string.
+     */
+    public SlingPathSuffix(final String suffixTemplate) {
 
-        final Matcher matcher = PARAMETER_PATTERN.matcher(parameterTemplate);
+        final Matcher matcher = PARAMETER_PATTERN.matcher(suffixTemplate);
 
         while (matcher.find()) {
             if (matcher.groupCount() == 1) {
@@ -54,6 +59,15 @@ public class SlingPathSuffix {
 
     }
 
+    /**
+     * Retrieves a suffix path parameter by its name from a specific request.
+     * @param name The name of the parameter. It should match a parameter name as specified
+     *             in the template provided at construction time.
+     * @param request The specific {@link SlingHttpServletRequest} from which to extract the
+     *                parameter.
+     * @return The path parameter value as extracted from the suffix. Null if such a parameter
+     * does not exist, or could not be found.
+     */
     public String getParam(final String name, SlingHttpServletRequest request) {
         return parametersByName(request.getRequestPathInfo().getSuffix()).get(name);
     }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
@@ -1,0 +1,74 @@
+package com.redhat.pantheon.servlet.util;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents the suffix of a sling url and allows to extract information from it.
+ * To be used primarily in servlets where suffix information contains input information
+ * (i.e. parameters).
+ * <br><br>
+ *
+ * Parameters may be extracted like so:
+ *
+ * <pre>{@code
+ * SlingPathSuffix suffix = new SlingPathSuffix("/path/with/{param1}/and/{param2}");
+ * suffix.getParam("param1", request);
+ * suffix.getParam("param2", request);
+ * }</pre>
+ *
+ * The suffix needs a template or pattern to be provided in order to be able to extract
+ * information from it. It may be a completely static pattern or contain placeholders for
+ * named parameters.
+ *
+ * @author Carlos Munoz
+ */
+public class SlingPathSuffix {
+
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("(\\{[a-zA-Z0-9]+})");
+    private final List<String> parameterNames = new ArrayList<>();
+    private Map<String, String> parameterMap;
+    private final Pattern pattern;
+
+    public SlingPathSuffix(final String parameterTemplate) {
+
+        final Matcher matcher = PARAMETER_PATTERN.matcher(parameterTemplate);
+
+        while (matcher.find()) {
+            if (matcher.groupCount() == 1) {
+                final String group = matcher.group(1);
+                if (group.length() > 2) {
+                    parameterNames.add(group.substring(1, group.length() - 1));
+                } else {
+                    parameterNames.add(group);
+                }
+            }
+        }
+        pattern = Pattern.compile(Pattern.quote(matcher.replaceAll("_____PARAM_____")).replace("_____PARAM_____", "\\E([^/]*)\\Q"));
+
+    }
+
+    public String getParam(final String name, SlingHttpServletRequest request) {
+        return parametersByName(request.getRequestPathInfo().getSuffix()).get(name);
+    }
+
+    private Map<String, String> parametersByName(final String uriString) {
+        if(parameterMap == null) {
+            parameterMap = new HashMap<>();
+            final Matcher matcher = pattern.matcher(uriString);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Uri does not match");
+            }
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                parameterMap.put(parameterNames.get(i - 1), matcher.group(i));
+            }
+        }
+        return parameterMap;
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
@@ -5,8 +5,7 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Carlos Munoz
@@ -19,8 +18,8 @@ class SlingPathSuffixTest {
     @Test
     void basicParameterTest() {
         // Given
-        sc.requestPathInfo().setSuffix("/path/value1/value2/other");
         SlingPathSuffix suffix = new SlingPathSuffix("/path/{param1}/{param2}/other");
+        sc.requestPathInfo().setSuffix("/path/value1/value2/other");
 
         // When
 
@@ -30,4 +29,15 @@ class SlingPathSuffixTest {
         assertNull(suffix.getParam("nonexisting", sc.request()));
     }
 
+    @Test
+    void partialSuffixSegmentParameters() {
+        // Given
+        SlingPathSuffix suffix = new SlingPathSuffix("/path/{param1}Suffix/other");
+        sc.requestPathInfo().setSuffix("/path/valueSuffix/other");
+
+        // When
+
+        // Then
+        assertEquals("value", suffix.getParam("param1", sc.request()));
+    }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
@@ -1,0 +1,33 @@
+package com.redhat.pantheon.servlet.util;
+
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author Carlos Munoz
+ */
+@ExtendWith({SlingContextExtension.class})
+class SlingPathSuffixTest {
+
+    SlingContext sc = new SlingContext();
+
+    @Test
+    void basicParameterTest() {
+        // Given
+        sc.requestPathInfo().setSuffix("/path/value1/value2/other");
+        SlingPathSuffix suffix = new SlingPathSuffix("/path/{param1}/{param2}/other");
+
+        // When
+
+        // Then
+        assertEquals("value1", suffix.getParam("param1", sc.request()));
+        assertEquals("value2", suffix.getParam("param2", sc.request()));
+        assertNull(suffix.getParam("nonexisting", sc.request()));
+    }
+
+}


### PR DESCRIPTION
Add a utility for dealing with Sling path suffixes. In this revision the utility allows for template-based extraction of path parameters, enabling building complex, non-static API paths.