### PR TITLE
Module uploads will now build canonical variant

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/Workspace.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/Workspace.java
@@ -5,8 +5,10 @@ import com.redhat.pantheon.model.api.Folder;
 import com.redhat.pantheon.model.api.OrderedFolder;
 import com.redhat.pantheon.model.api.SlingModel;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
+import com.redhat.pantheon.model.module.ModuleVariant;
 
 import javax.inject.Named;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -22,6 +24,11 @@ public interface Workspace extends SlingModel {
 
     @Named("entities")
     Child<Folder> entities();
+
+    default String getCanonicalVariantName() {
+        Optional<ModuleVariantDefinition> cv = moduleVariantDefinitions().getOrCreate().getVariants().filter(def -> def.isCanonical().get()).findFirst();
+        return cv.isPresent() ? cv.get().getName() : ModuleVariant.DEFAULT_VARIANT_NAME;
+    }
 
     @JcrPrimaryType("sling:OrderedFolder")
     interface ModuleVariantDefinitionFolder extends OrderedFolder {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
@@ -127,7 +127,13 @@ public class ModuleVersionUpload extends AbstractPostOperation {
                 asciidoctorService.getModuleHtml(module, localeObj, module.getWorkspace().getCanonicalVariantName(),
                         true, context, true);
 
-                Metadata metadata = moduleLocale.variants().getOrCreate().variant(moduleLocale.getWorkspace().getCanonicalVariantName()).getOrCreate().draft().getOrCreate().metadata().getOrCreate();
+                Metadata metadata = moduleLocale
+                        .variants().getOrCreate()
+                        .variant(
+                                moduleLocale.getWorkspace().getCanonicalVariantName())
+                        .getOrCreate()
+                        .draft().getOrCreate()
+                        .metadata().getOrCreate();
                 metadata.dateModified().set(Calendar.getInstance());
                 // Generate a module type based on the file name ONLY after asciidoc generation, so that the
                 // attribute-based logic takes precedence

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleVersionUpload.java
@@ -12,7 +12,6 @@ import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleLocale;
 import com.redhat.pantheon.model.module.ModuleType;
 import com.redhat.pantheon.servlet.ServletUtils;
-import com.redhat.pantheon.sling.ServiceResourceResolverProvider;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -60,14 +59,11 @@ public class ModuleVersionUpload extends AbstractPostOperation {
     private static final Logger log = LoggerFactory.getLogger(ModuleVersionUpload.class);
 
     private AsciidoctorService asciidoctorService;
-    private ServiceResourceResolverProvider serviceResourceResolverProvider;
 
     @Activate
     public ModuleVersionUpload(
-            @Reference AsciidoctorService asciidoctorService,
-            @Reference ServiceResourceResolverProvider serviceResourceResolverProvider) {
+            @Reference AsciidoctorService asciidoctorService) {
         this.asciidoctorService = asciidoctorService;
-        this.serviceResourceResolverProvider = serviceResourceResolverProvider;
     }
 
     @Override

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -42,9 +42,6 @@ class ModuleVersionUploadTest {
     @Mock
     AsciidoctorService asciidoctorService;
 
-    @Mock
-    ServiceResourceResolverProvider serviceResourceResolverProvider;
-
     @Test
     void createFirstVersion() throws Exception {
         // Given
@@ -59,11 +56,9 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
         registerMockAdapter(Workspace.class, slingContext);
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
@@ -105,11 +100,9 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
         registerMockAdapter(Workspace.class, slingContext);
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.SIMPLIFIED_CHINESE.toString());
         params.put("asciidoc", "å\u008D\u0097äº¬é\u0098²ç\u0096«ç\u008E°å\u009Cº");
@@ -151,11 +144,9 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
         registerMockAdapter(Workspace.class, slingContext);
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.SIMPLIFIED_CHINESE.toString());
         params.put("asciidoc", "南京防疫现场");
@@ -202,11 +193,9 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
         registerMockAdapter(Workspace.class, slingContext);
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", "en_US");
         params.put("asciidoc", "Draft asciidoc content");
@@ -264,11 +253,9 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
         registerMockAdapter(Workspace.class, slingContext);
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", "en_US");
         params.put("asciidoc", "Revised asciidoc content");
@@ -332,10 +319,8 @@ class ModuleVersionUploadTest {
                 asciidoctorService.getModuleHtml(
                         any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn("A generated html string");
-        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
-                .thenReturn(slingContext.resourceResolver());
 
-        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.US);
         params.put("asciidoc", "This is the draft adoc content");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -1,7 +1,10 @@
 package com.redhat.pantheon.servlet.module;
 
+import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.model.api.SlingModels;
 import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.workspace.Workspace;
+import com.redhat.pantheon.sling.ServiceResourceResolverProvider;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.servlets.post.HtmlResponse;
@@ -10,6 +13,7 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.http.HttpServletResponse;
@@ -21,12 +25,22 @@ import static com.google.common.collect.Maps.newHashMap;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 class ModuleVersionUploadTest {
 
     private SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Mock
+    AsciidoctorService asciidoctorService;
+
+    @Mock
+    ServiceResourceResolverProvider serviceResourceResolverProvider;
 
     @Test
     void createFirstVersion() throws Exception {
@@ -34,8 +48,19 @@ class ModuleVersionUploadTest {
         slingContext.build()
                 .resource("/content/repositories/test_workspace",
                         "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/test_workspace/module_variants/singleVariant",
+                        "pant:canonical", true)
                 .commit();
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        registerMockAdapter(Workspace.class, slingContext);
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", "es_ES");
         params.put("asciidoc", "This is the adoc content");
@@ -49,7 +74,7 @@ class ModuleVersionUploadTest {
         // Then
         assertEquals(HttpServletResponse.SC_CREATED, response.getStatusCode());
         assertNotNull(slingContext.resourceResolver().getResource("/content/repositories/test_workspace/entities/new/proc_module/es_ES/source/draft/jcr:content"));
-        assertNull(slingContext.resourceResolver().getResource("/content/repositories/test_workspace/entities/new/proc_module/es_ES/variants"));
+        assertNotNull(slingContext.resourceResolver().getResource("/content/repositories/test_workspace/entities/new/proc_module/es_ES/variants"));
 
         Module module =
                 SlingModels.getModel(
@@ -71,7 +96,16 @@ class ModuleVersionUploadTest {
                 .resource("/content/repositories/test_workspace",
                         "jcr:primaryType", "pant:workspace")
                 .commit();
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        registerMockAdapter(Workspace.class, slingContext);
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.SIMPLIFIED_CHINESE.toString());
         params.put("asciidoc", "å\u008D\u0097äº¬é\u0098²ç\u0096«ç\u008E°å\u009Cº");
@@ -107,7 +141,16 @@ class ModuleVersionUploadTest {
                 .resource("/content/repositories/test_workspace",
                         "jcr:primaryType", "pant:workspace")
                 .commit();
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        registerMockAdapter(Workspace.class, slingContext);
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.SIMPLIFIED_CHINESE.toString());
         params.put("asciidoc", "南京防疫现场");
@@ -148,7 +191,16 @@ class ModuleVersionUploadTest {
                         "jcr:data", "This is the released adoc content")
                 .commit();
         // set the draft and released 'pointers'
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        registerMockAdapter(Workspace.class, slingContext);
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", "en_US");
         params.put("asciidoc", "Draft asciidoc content");
@@ -200,7 +252,16 @@ class ModuleVersionUploadTest {
                 .resource("/content/repositories/test_workspace/entities/new/module/en_US/source/released/jcr:content",
                         "jcr:data", "This is the released adoc content")
                 .commit();
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+        registerMockAdapter(Workspace.class, slingContext);
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", "en_US");
         params.put("asciidoc", "Revised asciidoc content");
@@ -258,7 +319,15 @@ class ModuleVersionUploadTest {
                 .resource("/content/repositories/test_workspace/entities/new/module/en_US/source/released/jcr:content",
                         "jcr:data", "This is the released adoc content")
                 .commit();
-        ModuleVersionUpload upload = new ModuleVersionUpload();
+
+        lenient().when(
+                asciidoctorService.getModuleHtml(
+                        any(Module.class), any(Locale.class), anyString(), anyBoolean(), anyMap(), anyBoolean()))
+                .thenReturn("A generated html string");
+        lenient().when(serviceResourceResolverProvider.getServiceResourceResolver())
+                .thenReturn(slingContext.resourceResolver());
+
+        ModuleVersionUpload upload = new ModuleVersionUpload(asciidoctorService, serviceResourceResolverProvider);
         Map<String, Object> params = newHashMap();
         params.put("locale", Locale.US);
         params.put("asciidoc", "This is the draft adoc content");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -29,7 +29,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @ExtendWith({SlingContextExtension.class, MockitoExtension.class})
 class ModuleVersionUploadTest {
@@ -87,6 +90,7 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
     @Test
@@ -132,6 +136,7 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
     @Test
@@ -177,6 +182,7 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
     @Test
@@ -237,6 +243,7 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
     @Test
@@ -298,6 +305,7 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
     @Test
@@ -364,5 +372,6 @@ class ModuleVersionUploadTest {
                         .jcrContent().get()
                         .jcrData().get()
         );
+        verifyZeroInteractions(asciidoctorService);
     }
 }


### PR DESCRIPTION
Variant selected is either the first match if any variant definitions have the canonical flag set, otherwise it builds the "DEFAULT" variant for modules.

One thing this does NOT have is the logic to copy metadata from any old released version onto the draft version. Is that functionality we still want? @xdavidson @carlosmunoz 