### PR TITLE
remove edge cases from sling suffix analyzer

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
@@ -55,8 +55,11 @@ public class SlingPathSuffix {
                 }
             }
         }
-        pattern = Pattern.compile(Pattern.quote(matcher.replaceAll("_____PARAM_____")).replace("_____PARAM_____", "\\E([^/]*)\\Q"));
-
+        pattern = Pattern.compile(
+                Pattern.quote(matcher.replaceAll("_____PARAM_____"))
+                        .replace("_____PARAM_____", "\\E([^/\\?#]*)\\Q")
+                        // add this in case the url has extra parameters
+                        + ".*");
     }
 
     /**

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/SlingPathSuffix.java
@@ -3,11 +3,13 @@ package com.redhat.pantheon.servlet.util;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Represents the suffix of a sling url and allows to extract information from it.
@@ -32,6 +34,8 @@ import java.util.regex.Pattern;
 public class SlingPathSuffix {
 
     private static final Pattern PARAMETER_PATTERN = Pattern.compile("(\\{[a-zA-Z0-9]+})");
+    // A list of the characters denoting the end of a resource path
+    private static final String PATH_END_CHARS = escapeCharsForRegex('/', '?', '#');
     private final List<String> parameterNames = new ArrayList<>();
     private Map<String, String> parameterMap;
     private final Pattern pattern;
@@ -57,8 +61,8 @@ public class SlingPathSuffix {
         }
         pattern = Pattern.compile(
                 Pattern.quote(matcher.replaceAll("_____PARAM_____"))
-                        .replace("_____PARAM_____", "\\E([^/\\?#]*)\\Q")
-                        // add this in case the url has extra parameters
+                        .replace("_____PARAM_____", "\\E([^" + PATH_END_CHARS + "]*)\\Q")
+                        // add this in case the url has extra 'things' (like parameters)
                         + ".*");
     }
 
@@ -87,5 +91,15 @@ public class SlingPathSuffix {
             }
         }
         return parameterMap;
+    }
+
+    /**
+     * Escapes each provided character individually and returns a string
+     * with the escaped characters for use in regular expressions.
+     */
+    private static String escapeCharsForRegex(Character ... chars) {
+        return Arrays.stream(chars)
+                .map(character -> Pattern.quote(character.toString()))
+                .collect(Collectors.joining());
     }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/SlingPathSuffixTest.java
@@ -40,4 +40,28 @@ class SlingPathSuffixTest {
         // Then
         assertEquals("value", suffix.getParam("param1", sc.request()));
     }
+
+    @Test
+    void suffixWithExtraQueryParameters() {
+        // Given
+        SlingPathSuffix suffix = new SlingPathSuffix("/path/{param1}");
+        sc.requestPathInfo().setSuffix("/path/param1Segment?v=1");
+
+        // When
+
+        // Then
+        assertEquals("param1Segment", suffix.getParam("param1", sc.request()));
+    }
+
+    @Test
+    void suffixWithClientHash() {
+        // Given
+        SlingPathSuffix suffix = new SlingPathSuffix("/path/{param1}");
+        sc.requestPathInfo().setSuffix("/path/param1Segment#clientid");
+
+        // When
+
+        // Then
+        assertEquals("param1Segment", suffix.getParam("param1", sc.request()));
+    }
 }


### PR DESCRIPTION
Before this revision, the `SlingPathSuffix` class failed to recognize url sections after the path (e.g. query parameters). In this revision, the following two edge cases are resolved:

Suffixes with query parameters (e.g. `/path/example?q=a`)
Suffixes with client fragment (e.g. `/path/example#clientid`)