### PR TITLE
fixing build-on-upload with no variants defined; CCS-3682

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/ModuleVariantDefinition.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/ModuleVariantDefinition.java
@@ -10,6 +10,8 @@ import javax.inject.Named;
  */
 public interface ModuleVariantDefinition extends SlingModel {
 
+    public static final String DEFAULT_VARIANT_NAME = "DEFAULT";
+
     // TODO We might not need this, as the identifier will be the node name
     // There might be potential conflicts.... but we could impose rules on the naming schema for variants
     @Deprecated
@@ -20,6 +22,15 @@ public interface ModuleVariantDefinition extends SlingModel {
     Field<String> attributesFilePath();
 
     @Named("pant:canonical")
-    Field<Boolean> isCanonical();
+    Field<Boolean> canonical();
 
+    default boolean isCanonical() {
+        if (DEFAULT_VARIANT_NAME.equals(getName())) {
+            return true;
+        } else if (canonical() == null) {
+            return false;
+        } else {
+            return canonical().get();
+        }
+    }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/Workspace.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/Workspace.java
@@ -26,7 +26,7 @@ public interface Workspace extends SlingModel {
     Child<Folder> entities();
 
     default String getCanonicalVariantName() {
-        Optional<ModuleVariantDefinition> cv = moduleVariantDefinitions().getOrCreate().getVariants().filter(def -> def.isCanonical().get()).findFirst();
+        Optional<ModuleVariantDefinition> cv = moduleVariantDefinitions().getOrCreate().getVariants().filter(def -> def.isCanonical()).findFirst();
         return cv.isPresent() ? cv.get().getName() : ModuleVariant.DEFAULT_VARIANT_NAME;
     }
 


### PR DESCRIPTION
Previously, trying to upload documents with an empty `variants` section of the pantheon2.yml file would result in 500 server errors for modules. This should fix that.