### PR TITLE
Configuration for logging request data

### DIFF
--- a/pantheon-karaf-feature/src/main/feature/feature.xml
+++ b/pantheon-karaf-feature/src/main/feature/feature.xml
@@ -92,6 +92,12 @@
             db=${env:MONGO_DB}
             repository.home=${env:REPOSITORY}
         </config>
+        <config name="org.apache.sling.engine.impl.log.RequestLoggerService">
+            request.log.service.format = %h %m %u %t %f "%r" %>s %b "%\{Referer}i" "%\{User-Agent}i"
+            request.log.service.onentry = true
+            request.log.service.output = data/log/request.log
+            request.log.service.outputtype = 1
+        </config>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.9</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.9.9</bundle>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.9.9</bundle>


### PR DESCRIPTION
This PR adds configuration that would log request details in <karaf_home>/data/logs/request.log. The changes is to configure Sling's RequestLoggerService[1] to output specific details of the request.

[1] - https://sling.apache.org/documentation/development/client-request-logging.html