### PR TITLE
update role name pant:abstract

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -111,7 +111,7 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
                 allNodes.stream()
                         .filter(block -> {
                             try {
-                                return block.getRoles().contains("abstract");
+                                return block.getRoles().contains("pantheon:abstract");
                             } catch (Exception e) {
                                 // Asciidoctor (the Ruby code) throws certain exceptions when properties are not available.
                                 // In this case 'context' might not be available, and so the filter should just

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ModuleMetadataExtractorTreeProcessorTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ModuleMetadataExtractorTreeProcessorTest.java
@@ -37,7 +37,7 @@ class ModuleMetadataExtractorTreeProcessorTest {
         final String adocContent = "= A title for content" +
                 "\n" +
                 "\n" +
-                "[.abstract]\n" +
+                "[.pantheon:abstract]\n" +
                 "This is the module abstract";
 
         // When


### PR DESCRIPTION

This PR update the role name for pant:abstract. On metadata node, the abstract is stored as pant:abstract attribute