### PR TITLE
Update varaint API to support field mapping on the hydra team

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -110,6 +110,8 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
         // Striping out the jcr: from key name
         String variant_uuid = (String) variantMap.remove("jcr:uuid");
         variantMap.put("variant_uuid", variant_uuid);
+        // TODO: remove module_uuid after Hydra team releases UNIFIED-6570
+        variantMap.put("module_uuid", variant_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         variantMap.put("date_modified", dateModified.toInstant().toString());


### PR DESCRIPTION
UNIFIED-6570 is open for Hydra team to update the mapping on their end. Till then Hydra team expects module_uuid field in their mapping integration with search. 