### PR TITLE
CCS-3716: Add more logging for golang app

### DIFF
--- a/tools/git2pantheon/git_uploader.go
+++ b/tools/git2pantheon/git_uploader.go
@@ -33,7 +33,7 @@ func gitClone(repository string, branch string, directory string) {
 
 func getUploader() {
 	if _, err := os.Stat("./pantheon.py"); os.IsNotExist(err) {
-		const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"
+		const uploader_url = "https://raw.githubusercontent.com/aprajshekhar/pantheon/ap_request_data_log/uploader/pantheon.py"
 		args := []string{"-o", "./pantheon.py", uploader_url}
 		cmd := exec.Command("curl", args...)
 		out, err := cmd.Output()
@@ -56,6 +56,7 @@ func push2Pantheon(directory string) {
 		var user = os.Getenv("UPLOADER_USER")
 		var password = os.Getenv("UPLOADER_PASSWORD")
 		var server = os.Getenv("PANTHEON_SERVER")
+		log.Printf("Using user %s, directory %s, and pantheon server %s ", user, directory, server)
 		args := []string{"pantheon.py", "push", "--user", user, "--password", password, "--directory", directory, "--server", server}
 		if user == "" || password == "" || server == "" {
 			log.Print("Environment variables not found, using uploader and pantheon.yml settings.")
@@ -63,9 +64,14 @@ func push2Pantheon(directory string) {
 		}
 		//Now call python
 		cmd := exec.Command("python3", args...)
+
 		out, err := cmd.Output()
 
-		log.Print(err)
+		//Print error if only its not null
+		if err != nil {
+			log.Print(err)
+		}
+
 		log.Print(string(out))
 	}
 

--- a/tools/git2pantheon/git_uploader.go
+++ b/tools/git2pantheon/git_uploader.go
@@ -33,7 +33,7 @@ func gitClone(repository string, branch string, directory string) {
 
 func getUploader() {
 	if _, err := os.Stat("./pantheon.py"); os.IsNotExist(err) {
-		const uploader_url = "https://raw.githubusercontent.com/aprajshekhar/pantheon/ap_request_data_log/uploader/pantheon.py"
+		const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"
 		args := []string{"-o", "./pantheon.py", uploader_url}
 		cmd := exec.Command("curl", args...)
 		out, err := cmd.Output()

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -261,7 +261,8 @@ def process_file(path, filetype):
 
         if not args.dry:
             r = requests.post(url, headers=HEADERS, data=data, files=files, auth=(args.user, pw))
-            _print_response('module', path, r.status_code, r.reason)
+            # print the response content received from Pantheon, not just reason
+            _print_response('module', path, r.status_code, r.text)
     elif isResource:
         if os.path.islink(path):
             target = str(os.readlink(path))
@@ -274,7 +275,8 @@ def process_file(path, filetype):
                 symlinkData['jcr:primaryType'] = 'pant:symlink'
                 symlinkData['pant:target'] = target
                 r = requests.post(url, headers=HEADERS, data=symlinkData, auth=(args.user, pw))
-                _print_response('symlink', path, r.status_code, r.reason)
+                # print the response content received from Pantheon, not just reason
+                _print_response('symlink', path, r.status_code, r.text)
 
         else:
             # determine the file content type, for some common ones
@@ -286,7 +288,8 @@ def process_file(path, filetype):
             files = {path.name: (path.name, open(path, 'rb'), file_type)}
             if not args.dry:
                 r = requests.post(url, headers=HEADERS, files=files, auth=(args.user, pw))
-                _print_response('resource', path, r.status_code, r.reason)
+                # print the response content received from Pantheon, not just reason
+                _print_response('resource', path, r.status_code, r.text)
     elif isAssembly:
         url += '/' + path.name
         logger.debug('url: %s', url)
@@ -298,7 +301,8 @@ def process_file(path, filetype):
 
         if not args.dry:
             r = requests.post(url, headers=HEADERS, data=data, files=files, auth=(args.user, pw))
-            _print_response('assembly', path, r.status_code, r.reason)
+            # print the response content received from Pantheon, not just reason
+            _print_response('assembly', path, r.status_code, r.text)
     logger.debug('')
 
 

--- a/uploader/pantheon.py
+++ b/uploader/pantheon.py
@@ -388,11 +388,11 @@ def createVariant(data, path, url, workspace):
     # print(payload)
     if not args.dry:
         r: Response = requests.post(url, headers=HEADERS, data=workspace, auth=(args.user, pw))
-        _print_response('workspace', path, r.status_code, r.reason)
+        _print_response('workspace', path, r.status_code, r.text)
         if r.status_code == 200 or r.status_code == 201:
             url = url + '/' + 'module_variants'
             r: Response = requests.post(url, headers=HEADERS, data=payload, auth=(args.user, pw))
-            _print_response('module_variants', list(data.keys()), r.status_code, r.reason)
+            _print_response('module_variants', list(data.keys()), r.status_code, r.text)
     logger.debug('')
 
 


### PR DESCRIPTION
This PR:

1. Logs  server, directory, and user being used for calling uploader in GoApp.
2. Checks whether error is null or not before logging error in GoApp.
3. Logs the response received from Pantheon in uploader so that GoApp can log the actual response text from pantheon rather than reason (OK/Internal Server Error etc.)