### PR TITLE
Ccs 3333 assembly metadata

### DIFF
--- a/pantheon-bundle/frontend/src/app/Constants.tsx
+++ b/pantheon-bundle/frontend/src/app/Constants.tsx
@@ -6,7 +6,7 @@ export class Fields {
     public static PANT_MODULE_TYPE = 'moduleType'
     public static NAME = 'name'
     public static PANT_PUBLISHED_DATE = 'pant:publishedDate'
-    public static PANT_DATE_UPLOADED = 'pant:dateUploaded'    
+    public static PANT_DATE_UPLOADED = 'pant:dateUploaded'
     public static SLING_RESOURCETYPE = 'sling:resourceType'
     public static PANT_PRODUCT_VERSION_REF = 'productVersion'
 }
@@ -19,6 +19,11 @@ export class JcrTypes {
 // tslint:disable-next-line: max-classes-per-file
 export class SlingTypes {
     public static PRODUCT_VERSION = 'pantheon/productVersion'
+}
+
+// tslint:disable-next-line: max-classes-per-file
+export class SlingTypesPrefixes {
+    public static PANTHEON = 'pantheon'
 }
 
 // tslint:disable-next-line: max-classes-per-file

--- a/pantheon-bundle/frontend/src/app/Constants.tsx
+++ b/pantheon-bundle/frontend/src/app/Constants.tsx
@@ -20,3 +20,9 @@ export class JcrTypes {
 export class SlingTypes {
     public static PRODUCT_VERSION = 'pantheon/productVersion'
 }
+
+// tslint:disable-next-line: max-classes-per-file
+export class PathPrefixes {
+    public static MODULE_PATH_PREFIX = '/module'
+    public static ASSEBMLY_PATH_PREFIX = '/assembly'
+}

--- a/pantheon-bundle/frontend/src/app/__snapshots__/versions.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/versions.test.tsx.snap
@@ -103,12 +103,6 @@ exports[`Versions tests should render Versions component 1`] = `
         >
           Edit Metadata
         </Title>
-        <br />
-        <p
-          className="pf-u-pl-sm"
-        >
-          All fields are required.
-        </p>
       </React.Fragment>
     }
     hideTitle={false}
@@ -170,6 +164,7 @@ exports[`Versions tests should render Versions component 1`] = `
       </FormGroup>
       <FormGroup
         fieldId="document-usecase"
+        helperText="Explanations of document user cases included in documentation."
         isRequired={true}
         label="Document use case"
       >
@@ -253,7 +248,6 @@ exports[`Versions tests should render Versions component 1`] = `
       </FormGroup>
       <FormGroup
         fieldId="url-fragment"
-        isRequired={true}
         label="Vanity URL fragment"
       >
         <InputGroup>
@@ -271,7 +265,7 @@ exports[`Versions tests should render Versions component 1`] = `
             id="url-fragment"
             isDisabled={false}
             isReadOnly={false}
-            isRequired={true}
+            isRequired={false}
             isValid={true}
             onChange={[Function]}
             placeholder="Enter URL"

--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
@@ -6,7 +6,7 @@ import {
     DataListCell, Card, Text, TextContent, TextVariants
 } from '@patternfly/react-core'
 import { Versions } from '@app/versions'
-import { Fields } from '@app/Constants'
+import { Fields, PathPrefixes } from '@app/Constants'
 import { continueStatement } from '@babel/types';
 
 class AssemblyDisplay extends Component<any, any, any> {
@@ -83,7 +83,7 @@ class AssemblyDisplay extends Component<any, any, any> {
                         <LevelItem>{}</LevelItem>
                         <LevelItem>{}</LevelItem>
                         <LevelItem>
-                            <Button variant='primary' onClick={() => this.generateDraftHtml(this.props.location.pathname)}>Generate Draft Html</Button>{'  '}
+                        <Button variant='primary' onClick={() => this.generateDraftHtml(this.props.location.pathname)}>Generate Draft Html</Button>{'  '}
                         </LevelItem>
                     </Level>
                     <br />
@@ -157,7 +157,7 @@ class AssemblyDisplay extends Component<any, any, any> {
         )
     }
     private generateDraftHtml = (pathname: any) => {
-        const docPath = '/content' + pathname + '.preview?draft=true&variant=' + this.state.variant
+        const docPath = '/content' + pathname.substring(PathPrefixes.ASSEBMLY_PATH_PREFIX.length) + '.preview?draft=true&variant=' + this.state.variant
 
         // console.log('Preview path: ', docPath)
         return window.open(docPath)
@@ -174,12 +174,13 @@ class AssemblyDisplay extends Component<any, any, any> {
 
     private fetchModuleDetails = async(data) => {
         await this.getVariantParam()
+        const path = data.location.pathname.substring(PathPrefixes.ASSEBMLY_PATH_PREFIX.length)
         this.setState({
-            modulePath: data.location.pathname.substring(9),
-            releasePath: "/content" + data.location.pathname.substring(9) + ".preview?variant=" + this.state.variant
+            modulePath: path,
+            releasePath: "/content" + path + ".preview?variant=" + this.state.variant
         })
 
-        fetch(data.location.pathname.substring(9) + '/en_US.harray.4.json')
+        fetch(path + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
                 // console.log('fetch results:', responseJSON)
@@ -238,7 +239,7 @@ class AssemblyDisplay extends Component<any, any, any> {
 
     private getVersionUUID = (path) => {
         // Remove /assembly from path
-        path = path.substring(9)
+        path = path.substring(PathPrefixes.ASSEBMLY_PATH_PREFIX.length)
         // path = "/content" + path + "/en_US/1/metadata.json"
         path = "/content" + path + "/en_US.harray.4.json"
         fetch(path)

--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
@@ -175,11 +175,11 @@ class AssemblyDisplay extends Component<any, any, any> {
     private fetchModuleDetails = async(data) => {
         await this.getVariantParam()
         this.setState({
-            modulePath: data.location.pathname,
-            releasePath: "/content" + data.location.pathname + ".preview?variant=" + this.state.variant
+            modulePath: data.location.pathname.substring(9),
+            releasePath: "/content" + data.location.pathname.substring(9) + ".preview?variant=" + this.state.variant
         })
 
-        fetch(data.location.pathname + '/en_US.harray.4.json')
+        fetch(data.location.pathname.substring(9) + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
                 // console.log('fetch results:', responseJSON)
@@ -237,6 +237,8 @@ class AssemblyDisplay extends Component<any, any, any> {
     }
 
     private getVersionUUID = (path) => {
+        // Remove /assembly from path
+        path = path.substring(9)
         // path = "/content" + path + "/en_US/1/metadata.json"
         path = "/content" + path + "/en_US.harray.4.json"
         fetch(path)

--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
@@ -1,0 +1,338 @@
+import React, { Component } from 'react'
+import { CopyIcon } from '@patternfly/react-icons';
+import { Level, LevelItem, Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core'
+import {
+    DataList, DataListItem, DataListItemRow, DataListItemCells,
+    DataListCell, Card, Text, TextContent, TextVariants
+} from '@patternfly/react-core'
+import { Versions } from '@app/versions'
+import { Fields } from '@app/Constants'
+import { continueStatement } from '@babel/types';
+
+class AssemblyDisplay extends Component<any, any, any> {
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            copySuccess: '',
+            draftPath: '',
+            draftUpdateDate: '',
+            modulePath: '',
+            moduleTitle: "",
+            moduleType: '',
+            variantUUID: '',
+            portalHost: '',
+            productValue: "",
+            releasePath: '',
+            releaseUpdateDate: '',
+            releaseVersion: '',
+            results: {},
+            variant: 'DEFAULT',
+            versionValue: ""
+        }
+    }
+
+    public componentDidMount() {
+        // this.getVariantParam()
+        this.fetchModuleDetails(this.props)
+        this.getVersionUUID(this.props.location.pathname)
+        this.getPortalUrl()
+    }
+
+    public render() {
+        // console.log('Props: ', this.props)
+        return (
+            <React.Fragment>
+                <div>
+                    <div className="app-container">
+                        <Breadcrumb>
+                            <BreadcrumbItem ><a href="#/search">Assemblies</a></BreadcrumbItem>
+                            <BreadcrumbItem to="#" isActive={true}>{this.state.moduleTitle}</BreadcrumbItem>
+                        </Breadcrumb>
+                    </div>
+                    <br />
+                    <div>
+                        <Level gutter="md">
+                            <LevelItem>
+                                <TextContent>
+                                    <Text component={TextVariants.h1}>{this.state.moduleTitle}</Text>
+                                </TextContent>
+                            </LevelItem>
+                            <LevelItem />
+                        </Level>
+                    </div>
+                    <div>
+                        {this.state.releaseUpdateDate.trim() !== "" && this.state.releaseUpdateDate !== '-'
+                            && this.state.variantUUID !== ""
+                            && this.state.portalHost !== ""
+                            && <span><a href={this.state.portalHost + '/topics/en-us/' + this.state.variantUUID} target="_blank">View on Customer Portal  <i className="fa pf-icon-arrow" /></a> </span>
+                        }
+
+                        <span>&emsp;&emsp;</span>
+
+                        {this.state.releaseUpdateDate.trim() !== "" && this.state.releaseUpdateDate !== '-'
+                            && this.state.variantUUID !== ""
+                            && this.state.portalHost !== ""
+                            && <span><a id="permanentURL" onClick={this.copyToClipboard} onMouseLeave={this.mouseLeave}>Copy permanent URL  <CopyIcon /></a></span>
+                        }
+
+                        <span>&emsp;{this.state.copySuccess !== '' && this.state.copySuccess}</span>
+                    </div>
+                    <br />
+                    <Level gutter="md">
+                        <LevelItem>{}</LevelItem>
+                        <LevelItem>{}</LevelItem>
+                        <LevelItem>
+                            <Button variant='primary' onClick={() => this.generateDraftHtml(this.props.location.pathname)}>Generate Draft Html</Button>{'  '}
+                        </LevelItem>
+                    </Level>
+                    <br />
+                    <div>
+                        <DataList aria-label="single action data list">
+                            <DataListItem aria-labelledby="simple-item1">
+                                <DataListItemRow id="data-rows-header" >
+                                    <DataListItemCells
+                                        dataListCells={[
+                                            <DataListCell width={2} key="product">
+                                                <span className="sp-prop-nosort" id="span-source-type-product">Product</span>
+                                            </DataListCell>,
+                                            <DataListCell key="published">
+                                                <span className="sp-prop-nosort" id="span-source-type-published">Published</span>
+                                            </DataListCell>,
+                                            <DataListCell key="updated">
+                                                <span className="sp-prop-nosort" id="span-source-type-draft-uploaded">Draft Uploaded</span>
+                                            </DataListCell>,
+                                            <DataListCell key="module_type">
+                                                <span className="sp-prop-nosort" id="span-source-name-module-type">Module Type</span>
+                                            </DataListCell>
+                                        ]}
+                                    />
+                                </DataListItemRow>
+                                <DataListItemRow>
+                                    <DataListItemCells
+                                        dataListCells={[
+                                            <DataListCell width={2} key="product">
+                                                <span>{this.state.productValue + ' ' + this.state.versionValue}</span>
+                                            </DataListCell>,
+                                            <DataListCell key="published">
+                                                <span>
+                                                    {this.state.releaseUpdateDate.trim() !== ""
+                                                        && this.state.releaseUpdateDate.length >= 15 ?
+                                                        this.state.releaseUpdateDate : "-"} <br />
+                                                    {this.state.releaseUpdateDate.trim() !== "" &&
+                                                        <a href={this.state.releasePath} target="_blank">{this.state.releaseVersion}</a>}
+                                                </span>
+                                            </DataListCell>,
+                                            <DataListCell key="updated">
+                                                <span>
+                                                    {this.state.draftUpdateDate.trim() !== ""
+                                                        && this.state.draftUpdateDate.length >= 15 ?
+                                                        this.state.draftUpdateDate : "-"}
+                                                </span>
+                                            </DataListCell>,
+                                            <DataListCell key="module_type">
+                                                <span>{this.state.moduleType !== undefined ? this.state.moduleType : "-"}</span>
+                                            </DataListCell>,
+                                        ]}
+                                    />
+                                </DataListItemRow>
+                            </DataListItem>
+                        </DataList>
+                    </div>
+                    <div>
+                        <Card>
+                            <Versions
+                                modulePath={this.state.modulePath}
+                                productInfo={this.state.productValue}
+                                versionModulePath={this.state.moduleTitle}
+                                variant={this.state.variant}
+                                updateDate={this.updateDate}
+                                onGetProduct={this.getProduct}
+                                onGetVersion={this.getVersion}
+                            />
+                        </Card>
+                    </div>
+                </div>
+            </React.Fragment>
+        )
+    }
+    private generateDraftHtml = (pathname: any) => {
+        const docPath = '/content' + pathname + '.preview?draft=true&variant=' + this.state.variant
+
+        // console.log('Preview path: ', docPath)
+        return window.open(docPath)
+    }
+
+    private updateDate = (draftDate, releaseDate, releaseVersion, variantUUID) => {
+        this.setState({
+            draftUpdateDate: draftDate,
+            variantUUID,
+            releaseUpdateDate: releaseDate,
+            releaseVersion,
+        })
+    }
+
+    private fetchModuleDetails = async(data) => {
+        await this.getVariantParam()
+        this.setState({
+            modulePath: data.location.pathname,
+            releasePath: "/content" + data.location.pathname + ".preview?variant=" + this.state.variant
+        })
+
+        fetch(data.location.pathname + '/en_US.harray.4.json')
+            .then(response => response.json())
+            .then(responseJSON => {
+                // console.log('fetch results:', responseJSON)
+                // TODO: refactor for loops
+                for (const sourceVariant of responseJSON.__children__) {
+                    if (!sourceVariant.__children__) {
+                        continue
+                    }
+                    for (const myChild of sourceVariant.__children__) {
+
+                        if (!myChild.__children__) {
+                            continue
+                        }
+                        if (myChild.__name__ === 'draft') {
+
+                            this.setState({ draftUpdateDate: myChild["jcr:created"] })
+                        }
+                        for (const myGrandchild of myChild.__children__) {
+                            if (!myGrandchild.__children__) {
+                                continue
+                            }
+
+                            for (const offspring of myGrandchild.__children__) {
+                                if (offspring.__name__ === 'metadata') {
+
+                                    if (offspring[Fields.JCR_TITLE] !== undefined) {
+
+                                        this.setState({
+                                            moduleTitle: offspring[Fields.JCR_TITLE],
+                                        })
+                                    }
+                                    if (offspring[Fields.PANT_MODULE_TYPE] !== undefined) {
+
+                                        this.setState({
+                                            moduleType: offspring[Fields.PANT_MODULE_TYPE],
+
+                                        })
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+
+            })
+    }
+
+    private getProduct = (product) => {
+        this.setState({ productValue: product })
+    }
+
+    private getVersion = (version) => {
+        this.setState({ versionValue: version })
+    }
+
+    private getVersionUUID = (path) => {
+        // path = "/content" + path + "/en_US/1/metadata.json"
+        path = "/content" + path + "/en_US.harray.4.json"
+        fetch(path)
+            .then(response => response.json())
+            .then((responseJSON) => {
+                for (const locale of responseJSON.__children__) {
+                    if (!locale.__children__) {
+                        continue
+                    }
+                    for (const localeChild of locale.__children__) {
+
+                        if (!localeChild.__children__) {
+                            continue
+                        }
+                        for (const variant of localeChild.__children__) {
+                            if (!variant.__children__) {
+                                continue
+                            }
+
+                            for (const offspring of variant.__children__) {
+                                if (offspring.__name__ === 'metadata') {
+
+                                    if (offspring[Fields.PANT_PRODUCT_VERSION_REF] !== undefined) {
+
+                                        this.getProductInitialLoad(offspring[Fields.PANT_PRODUCT_VERSION_REF])
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+            })
+    }
+
+    private getProductInitialLoad = (uuid) => {
+        const path = '/content/products.harray.3.json'
+        fetch(path)
+            .then(response => response.json())
+            .then(responseJSON => {
+                for (const product of responseJSON.__children__) {
+                    if (!product.__children__) {
+                        continue
+                    }
+                    for (const productChild of product.__children__) {
+                        if (productChild.__name__ !== 'versions') {
+                            continue
+                        }
+                        for (const productVersion of productChild.__children__) {
+                            if (productVersion[Fields.JCR_UUID] === uuid) {
+                                this.setState({ productValue: product.name, versionValue: productVersion.name })
+                                break
+                            }
+                        }
+                    }
+                }
+            })
+    }
+
+    private copyToClipboard = () => {
+        const textField = document.createElement('textarea')
+        if (this.state.variantUUID.trim() !== '') {
+            textField.value = this.state.portalHost + '/topics/en-us/' + this.state.variantUUID
+            document.body.appendChild(textField)
+            textField.select()
+            document.execCommand('copy')
+            textField.remove()
+            this.setState({ copySuccess: 'Copied!' })
+        }
+    }
+
+    private mouseLeave = () => {
+        this.setState({ copySuccess: '' })
+    }
+
+    private getPortalUrl = () => {
+        fetch('/conf/pantheon/pant:portalUrl')
+            .then(resp => {
+                if (resp.ok) {
+                    resp.text().then(text => {
+                        this.setState({ portalHost: text })
+                        // console.log("set portalHost: " + this.state.portalHost)
+                    })
+                }
+            })
+    }
+
+    private async getVariantParam() {
+        const query = new URLSearchParams(this.props.location.search);
+        const variantParam = query.get('variant')
+        // console.log("[moduleDisplay] variantParam => ", variantParam)
+        if (variantParam !== 'undefined') {
+            this.setState({ variant: variantParam })
+        }
+    }
+
+}
+
+export { AssemblyDisplay }

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -6,7 +6,7 @@ import {
     DataListCell, Card, Text, TextContent, TextVariants
 } from '@patternfly/react-core'
 import { Versions } from '@app/versions'
-import { Fields } from '@app/Constants'
+import { Fields, PathPrefixes } from '@app/Constants'
 import { continueStatement } from '@babel/types';
 
 class ModuleDisplay extends Component<any, any, any> {
@@ -157,7 +157,7 @@ class ModuleDisplay extends Component<any, any, any> {
         )
     }
     private generateDraftHtml = (pathname: any) => {
-        const docPath = '/content' + pathname + '.preview?draft=true&variant=' + this.state.variant
+        const docPath = '/content' + pathname.substring(PathPrefixes.MODULE_PATH_PREFIX.length) + '.preview?draft=true&variant=' + this.state.variant
 
         // console.log('Preview path: ', docPath)
         return window.open(docPath)
@@ -174,12 +174,13 @@ class ModuleDisplay extends Component<any, any, any> {
 
     private fetchModuleDetails = async(data) => {
         await this.getVariantParam()
+        const path = data.location.pathname.substring(PathPrefixes.MODULE_PATH_PREFIX.length)
         this.setState({
-            modulePath: data.location.pathname.substring(7),
-            releasePath: "/content" + data.location.pathname.substring(7) + ".preview?variant=" + this.state.variant
+            modulePath: path,
+            releasePath: "/content" + path + ".preview?variant=" + this.state.variant
         })
 
-        fetch(data.location.pathname.subtring(7) + '/en_US.harray.4.json')
+        fetch(path + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
                 // console.log('fetch results:', responseJSON)
@@ -238,7 +239,7 @@ class ModuleDisplay extends Component<any, any, any> {
 
     private getVersionUUID = (path) => {
         // remove /module from path
-        path = path.substring(7)
+        path = path.substring(PathPrefixes.MODULE_PATH_PREFIX.length)
         // path = "/content" + path + "/en_US/1/metadata.json"
         path = "/content" + path + "/en_US.harray.4.json"
         fetch(path)

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -175,11 +175,11 @@ class ModuleDisplay extends Component<any, any, any> {
     private fetchModuleDetails = async(data) => {
         await this.getVariantParam()
         this.setState({
-            modulePath: data.location.pathname,
-            releasePath: "/content" + data.location.pathname + ".preview?variant=" + this.state.variant
+            modulePath: data.location.pathname.substring(7),
+            releasePath: "/content" + data.location.pathname.substring(7) + ".preview?variant=" + this.state.variant
         })
 
-        fetch(data.location.pathname + '/en_US.harray.4.json')
+        fetch(data.location.pathname.subtring(7) + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
                 // console.log('fetch results:', responseJSON)
@@ -237,6 +237,8 @@ class ModuleDisplay extends Component<any, any, any> {
     }
 
     private getVersionUUID = (path) => {
+        // remove /module from path
+        path = path.substring(7)
         // path = "/content" + path + "/en_US/1/metadata.json"
         path = "/content" + path + "/en_US.harray.4.json"
         fetch(path)

--- a/pantheon-bundle/frontend/src/app/routes.tsx
+++ b/pantheon-bundle/frontend/src/app/routes.tsx
@@ -31,14 +31,6 @@ class Routes extends Component<IAppState> {
         path: '/search',
         requiresLogin: false
       },
-      // {
-      //   component: (routeProps) => <Module />,
-      //   exact: true,
-      //   icon: null,
-      //   label: '',
-      //   path: '/module',
-      //   requiresLogin: true
-      // },
       {
         component: (routeProps) => <Product />,
         exact: true,

--- a/pantheon-bundle/frontend/src/app/routes.tsx
+++ b/pantheon-bundle/frontend/src/app/routes.tsx
@@ -7,6 +7,7 @@ import { ProductListing } from '@app/productListing'
 import { Login } from '@app/login'
 import { GitImport } from './gitImport'
 import { ModuleDisplay } from '@app/moduleDisplay'
+import { AssemblyDisplay } from '@app/assemblyDisplay'
 import { IAppState } from './app'
 
 interface IAppRoute {
@@ -30,14 +31,14 @@ class Routes extends Component<IAppState> {
         path: '/search',
         requiresLogin: false
       },
-      {
-        component: (routeProps) => <Module />,
-        exact: true,
-        icon: null,
-        label: '',
-        path: '/module',
-        requiresLogin: true
-      },
+      // {
+      //   component: (routeProps) => <Module />,
+      //   exact: true,
+      //   icon: null,
+      //   label: '',
+      //   path: '/module',
+      //   requiresLogin: true
+      // },
       {
         component: (routeProps) => <Product />,
         exact: true,
@@ -75,7 +76,15 @@ class Routes extends Component<IAppState> {
         exact: false,
         icon: null,
         label: '', // Empty because we are using the Brand component to render the text.
-        path: '/:data',
+        path: '/module/:data',
+        requiresLogin: true
+      },
+      {
+        component: (routeProps) => <AssemblyDisplay {...routeProps} />,
+        exact: false,
+        icon: null,
+        label: '', // Empty because we are using the Brand component to render the text.
+        path: '/assembly/:data',
         requiresLogin: true
       }
     ]

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -19,6 +19,7 @@ export interface ISearchState {
   checkNextPageRow: string
   columns: string[]
   confirmDelete: boolean
+  contentType: string
   deleteState: string
   filterQuery: string
   isEmptyResults: boolean
@@ -52,6 +53,7 @@ class Search extends Component<IAppState, ISearchState> {
       checkNextPageRow: "",
       columns: ['Name', 'Description', 'Source Type', 'Source Name', 'Upload Time'],
       confirmDelete: false,
+      contentType: "module",
       deleteState: '',
       displayLoadIcon: true,
       filterQuery: '',
@@ -167,14 +169,16 @@ class Search extends Component<IAppState, ISearchState> {
                         name={data[Search.KEY_TRANSIENTPATH]}
                         onChange={this.handleDeleteCheckboxChange}
                         key={'checked_' + key}
-                      />}                                   
+                      />}
+                      {console.log("[search] data=>", data)}
+                      {console.log("[search] key=>", key)}                 
                     <DataListItemCells key={"cells_" + key}
                       dataListCells={[
                         <DataListCell key={"title_" + key} width={2}>
                           {this.props.userAuthenticated && data["jcr:title"] !== '-' &&
-                            <Link to={data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["jcr:title"]}</Link>}
+                            <Link to={data['sling:resourceType'].substring(8) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["jcr:title"]}</Link>}
                           {this.props.userAuthenticated && data["jcr:title"] === '-' && data["pant:transientPath"] &&
-                            <Link to={data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["pant:transientPath"]}</Link>}
+                            <Link to={data['sling:resourceType'].substring(8) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["pant:transientPath"]}</Link>}
                           {!this.props.userAuthenticated && data["jcr:title"] !== '-' &&
                             <a href={"/" + data['pant:transientPath'] + ".preview" + "?variant=" + data.variant} target="_blank">{data["jcr:title"]}</a>}
                           {!this.props.userAuthenticated && data["jcr:title"] === '-' && data["pant:transientPath"] &&

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -12,7 +12,7 @@ import { BrowserRouter as Router, Route, Link, Switch } from 'react-router-dom'
 import { IAppState } from '@app/app'
 import { SearchFilter } from '@app/searchFilter';
 import SpinImage from '@app/images/spin.gif';
-import { Fields } from '@app/Constants';
+import { Fields, SlingTypesPrefixes } from '@app/Constants';
 
 export interface ISearchState {
   alertOneVisible: boolean
@@ -174,9 +174,9 @@ class Search extends Component<IAppState, ISearchState> {
                       dataListCells={[
                         <DataListCell key={"title_" + key} width={2}>
                           {this.props.userAuthenticated && data["jcr:title"] !== '-' &&
-                            <Link to={data['sling:resourceType'].substring(8) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["jcr:title"]}</Link>}
+                            <Link to={data['sling:resourceType'].substring(SlingTypesPrefixes.PANTHEON.length) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["jcr:title"]}</Link>}
                           {this.props.userAuthenticated && data["jcr:title"] === '-' && data["pant:transientPath"] &&
-                            <Link to={data['sling:resourceType'].substring(8) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["pant:transientPath"]}</Link>}
+                            <Link to={data['sling:resourceType'].substring(SlingTypesPrefixes.PANTHEON.length) + "/" + data['pant:transientPath'] + "?variant=" + data.variant} key={"link_" + key}>{data["pant:transientPath"]}</Link>}
                           {!this.props.userAuthenticated && data["jcr:title"] !== '-' &&
                             <a href={"/" + data['pant:transientPath'] + ".preview" + "?variant=" + data.variant} target="_blank">{data["jcr:title"]}</a>}
                           {!this.props.userAuthenticated && data["jcr:title"] === '-' && data["pant:transientPath"] &&

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -170,8 +170,6 @@ class Search extends Component<IAppState, ISearchState> {
                         onChange={this.handleDeleteCheckboxChange}
                         key={'checked_' + key}
                       />}
-                      {console.log("[search] data=>", data)}
-                      {console.log("[search] key=>", key)}                 
                     <DataListItemCells key={"cells_" + key}
                       dataListCells={[
                         <DataListCell key={"title_" + key} width={2}>

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -100,10 +100,6 @@ class Versions extends Component<IProps, IState> {
                 <Title headingLevel={TitleLevel.h1} size={BaseSizes['2xl']}>
                     Edit Metadata
               </Title>
-                <br />
-                <p className='pf-u-pl-sm'>
-                    All fields are required.
-              </p>
             </React.Fragment>
         )
 
@@ -342,6 +338,7 @@ class Versions extends Component<IProps, IState> {
                             label='Document use case'
                             isRequired={true}
                             fieldId='document-usecase'
+                            helperText="Explanations of document user cases included in documentation."
                         >
                             <FormSelect value={this.state.usecaseValue} onChange={this.onChangeUsecase} aria-label='FormSelect Usecase'>
                                 {Versions.USE_CASES.map((option, key) => (
@@ -351,14 +348,13 @@ class Versions extends Component<IProps, IState> {
                         </FormGroup>
                         <FormGroup
                             label='Vanity URL fragment'
-                            isRequired={true}
                             fieldId='url-fragment'
                         >
                             <InputGroup>
                                 <InputGroupText id='slash' aria-label='/'>
                                     <span>/</span>
                                 </InputGroupText>
-                                <TextInput isRequired={true} id='url-fragment' type='text' placeholder='Enter URL' value={this.state.moduleUrl} onChange={this.handleURLInput} />
+                                <TextInput isRequired={false} id='url-fragment' type='text' placeholder='Enter URL' value={this.state.moduleUrl} onChange={this.handleURLInput} />
                             </InputGroup>
                         </FormGroup>
                         <FormGroup
@@ -554,8 +550,7 @@ class Versions extends Component<IProps, IState> {
         // save form data
         if (this.state.product.value === undefined || this.state.product.value === 'Select a Product' || this.state.product.value === ''
             || this.state.productVersion.uuid === undefined || this.state.productVersion.label === 'Select a Version' || this.state.productVersion.uuid === ''
-            || this.state.usecaseValue === undefined || this.state.usecaseValue === 'Select Use Case' || this.state.usecaseValue === ''
-            || this.state.moduleUrl.trim() === '') {
+            || this.state.usecaseValue === undefined || this.state.usecaseValue === 'Select Use Case' || this.state.usecaseValue === '') {
 
             this.setState({ isMissingFields: true })
         } else {
@@ -567,7 +562,7 @@ class Versions extends Component<IProps, IState> {
             const formData = new FormData(event.target.form)
             formData.append('productVersion', this.state.productVersion.uuid)
             formData.append('documentUsecase', this.state.usecaseValue)
-            formData.append('urlFragment', '/' + this.state.moduleUrl)
+            formData.append('urlFragment', this.state.moduleUrl === undefined ? '' : '/' + this.state.moduleUrl )
             formData.append('searchKeywords', this.state.keywords === undefined ? '' : this.state.keywords)
 
             fetch(this.state.metadataPath + '/metadata', {

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -310,7 +310,7 @@ class Versions extends Component<IProps, IState> {
                             <div className='notification-container'>
                                 <Alert
                                     variant='warning'
-                                    title='All fields are required.'
+                                    title=''
                                     action={<AlertActionCloseButton onClose={this.dismissNotification} />}
                                 />
                                 <br />


### PR DESCRIPTION
This PR introduces the following changes:

-  a new route to /assembly
- a new route to /module
- assembly detail page that's a copy and past of module detail. The actual assembly detail page will be worked on i a separate ticket
-  add/edit assembly metadata