### PR TITLE
CCS-3186: tables with empty cells cause error when generating html

### DIFF
--- a/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/block_table.html.haml
+++ b/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/block_table.html.haml
@@ -46,7 +46,7 @@
                 - head_scope = nil
                 - head_id = nil
                 - headers_attr = colsArray[columnCnt]
-              - haml_tag (tblsec == :head || cell.style == :header ? 'th' : 'td'), :<, :class=>['tableblock', "halign-#{cell.attr :halign}", "valign-#{cell.attr :valign}"],
+              - haml_tag (tblsec == :head || cell.style == :header ? 'th' : 'td'), :class=>['tableblock', "halign-#{cell.attr :halign}", "valign-#{cell.attr :valign}"],
                   :colspan=>cell.colspan, :rowspan=>cell.rowspan, :style=>cell_css_style, :scope=>head_scope, :id=>head_id, :headers=>headers_attr do
                 - if tblsec == :head
                   =cell_content

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidocTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidocTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  */
 public class AsciidocTest {
 
+    private static final String CUSTOM_HAML_TEMPLATES_PATH = "apps/pantheon/templates/haml";
+
     /*
      * CCS-3186: Ensure tables with empty cells don't throw an error when using Pantheon's
      * custom HAML templates
@@ -32,14 +34,14 @@ public class AsciidocTest {
                 "|Column 1 |          | Column 3\n" +
                 "|===" +
                 "";
+        OptionsBuilder options = OptionsBuilder.options()
+                .templateDir(
+                        new File(getClass().getClassLoader().getResource(CUSTOM_HAML_TEMPLATES_PATH).getFile()));
 
         // When
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
 
         // Then
-        OptionsBuilder options = OptionsBuilder.options()
-                .templateDir(
-                        new File(getClass().getClassLoader().getResource("apps/pantheon/templates/haml").getFile()));
         assertDoesNotThrow(() -> asciidoctor.convert(asciidocContent, options.get()));
     }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidocTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidocTest.java
@@ -1,0 +1,45 @@
+package com.redhat.pantheon.asciidoctor;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.OptionsBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * This test class should be used to contain any asciidoc specific tests; unrelated
+ * to the system functionality but related to the generation of the different formats
+ * from asciidoc.
+ */
+public class AsciidocTest {
+
+    /*
+     * CCS-3186: Ensure tables with empty cells don't throw an error when using Pantheon's
+     * custom HAML templates
+     */
+    @Test
+    void testEmptyTableGeneration() {
+        // Given
+        String asciidocContent = "" +
+                "# Asciidoctor with tables and empty cells\n" +
+                "\n" +
+                "This is a test asciidoctor\n" +
+                "\n" +
+                "|===\n" +
+                "|Header 1 | Header 2 | Header 3\n" +
+                "|Column 1 |          | Column 3\n" +
+                "|===" +
+                "";
+
+        // When
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+
+        // Then
+        OptionsBuilder options = OptionsBuilder.options()
+                .templateDir(
+                        new File(getClass().getClassLoader().getResource("apps/pantheon/templates/haml").getFile()));
+        assertDoesNotThrow(() -> asciidoctor.convert(asciidocContent, options.get()));
+    }
+}


### PR DESCRIPTION
Remove HAML flag that which causes an error when generating tables with empty cells.
The generated output of tables seems to be exactly the same (in terms of table structure)
as when generating a table with a {nbsp} cell.

