### PR TITLE
CCS-3763:  Build failure on OHC

### DIFF
--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -88,7 +88,6 @@ class ModuleVersionUploadTest {
         verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
-    //@Disabled("temporarily unblock QA deployment")
     @Test
     void createFirstVersionUnicodeIso() throws Exception {
         // Given
@@ -139,7 +138,7 @@ class ModuleVersionUploadTest {
         verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
-    //@Disabled("temporarily unblock QA deployment")
+    
     @Test
     void createFirstVersionUnicodeUtf() throws Exception {
         // Given

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -88,7 +88,7 @@ class ModuleVersionUploadTest {
         verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
-    @Disabled("temporarily unblock QA deployment")
+    //@Disabled("temporarily unblock QA deployment")
     @Test
     void createFirstVersionUnicodeIso() throws Exception {
         // Given

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleVersionUploadTest.java
@@ -139,7 +139,7 @@ class ModuleVersionUploadTest {
         verify(asciidoctorService).getModuleHtml(any(Module.class), any(Locale.class), anyString(), eq(true), anyMap(), eq(true));
     }
 
-    @Disabled("temporarily unblock QA deployment")
+    //@Disabled("temporarily unblock QA deployment")
     @Test
     void createFirstVersionUnicodeUtf() throws Exception {
         // Given


### PR DESCRIPTION
Reverts the disabling of locale based test cases.