### PR TITLE
rename assembly_uuid and module_uuid to uuid

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyJsonServlet.java
@@ -113,7 +113,9 @@ public class AssemblyJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Striping out the jcr: from key name
         String assemblyId = (String) assemblyMap.remove("jcr:uuid");
+        // TODO: This is deprecated, but left for backwards compatibility
         assemblyMap.put("assembly_uuid", assemblyId);
+        assemblyMap.put("uuid", assemblyId);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         assemblyMap.put("date_modified", dateModified.toInstant().toString());

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
@@ -119,7 +119,9 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Striping out the jcr: from key name
         String module_uuid = (String) moduleMap.remove("jcr:uuid");
+        // TODO: This is deprecated, but left for backwards compatibility
         moduleMap.put("module_uuid", module_uuid);
+        moduleMap.put("uuid", module_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         moduleMap.put("date_modified", dateModified.toInstant().toString());

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -111,7 +111,9 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
         String variant_uuid = (String) variantMap.remove("jcr:uuid");
         variantMap.put("variant_uuid", variant_uuid);
         // TODO: remove module_uuid after Hydra team releases UNIFIED-6570
+        // TODO: This is deprecated, but left for backwards compatibility
         variantMap.put("module_uuid", variant_uuid);
+        variantMap.put("uuid", variant_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         variantMap.put("date_modified", dateModified.toInstant().toString());

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyJsonServletTest.java
@@ -89,6 +89,8 @@ class AssemblyJsonServletTest {
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("assembly"));
         assertTrue(assemblyMap.containsKey("assembly_uuid"));
+        // TODO Remove this check when assembly_uuid is removed
+        assertTrue(assemblyMap.get("assembly_uuid").equals(assemblyMap.get("uuid")));
         assertTrue(assemblyMap.containsKey("products"));
         assertTrue(assemblyMap.containsKey("locale"));
         assertTrue(assemblyMap.containsKey("title"));

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
@@ -96,6 +96,8 @@ class ModuleJsonServletTest {
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("module"));
         assertTrue(moduleMap.containsKey("module_uuid"));
+        // TODO Remove this check when module_uuid is removed
+        assertTrue(moduleMap.get("module_uuid").equals(moduleMap.get("uuid")));
         assertTrue(moduleMap.containsKey("products"));
         assertTrue(moduleMap.containsKey("description"));
         assertTrue(moduleMap.containsKey("locale"));

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
@@ -77,6 +77,9 @@ public class VariantJsonServletTest {
         assertTrue(map.containsKey("status"));
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("module"));
+        // TODO Remove this check when module_uuid is removed
+        assertTrue(moduleMap.containsKey("uuid"));
+        assertTrue(moduleMap.containsKey("variant_uuid"));
         assertTrue(moduleMap.containsKey("products"));
         assertTrue(moduleMap.containsKey("description"));
         assertTrue(moduleMap.containsKey("locale"));


### PR DESCRIPTION
This change introduces a new `uuid` field in the module and assembly APIs which will contain the same value as the `module_uuid` and `assembly_uuid` respectively.
The previous fields are left in for backwards compatibility but are now deprecated.