### PR TITLE
use the abstract as the description in the module API

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/Field.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/Field.java
@@ -43,4 +43,15 @@ public interface Field<T> extends Supplier<T>, Consumer<T> {
      * @return A new field which produces/consumes values of a different type
      */
     <R> Field<R> toFieldType(Class<R> newFieldType);
+
+    /**
+     * Executes a function if there is a value in the field.
+     * @param consumer The function to execute when the value if present.
+     */
+    default void ifPresent(Consumer<T> consumer) {
+        T fieldValue = get();
+        if(fieldValue != null) {
+            consumer.accept(fieldValue);
+        }
+    }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/ModuleJsonServlet.java
@@ -109,7 +109,7 @@ public class ModuleJsonServlet extends AbstractJsonSingleQueryServlet {
         moduleMap.put("revision_id", releasedRevision.get().getName());
         moduleMap.put("title", releasedMetadata.get().title().get());
         moduleMap.put("headline", releasedMetadata.get().getValueMap().containsKey("pant:headline") ? releasedMetadata.get().headline().get() : "");
-        moduleMap.put("description", releasedMetadata.get().description().get());
+        releasedMetadata.get().mAbstract().ifPresent(s -> moduleMap.put("description", s));
         moduleMap.put("content_type", CONTENT_TYPE);
         moduleMap.put("date_published", releasedMetadata.get().getValueMap().containsKey("pant:datePublished") ? releasedMetadata.get().datePublished().get().toInstant().toString() : "");
         moduleMap.put("status", "published");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/ModuleJsonServletTest.java
@@ -74,7 +74,8 @@ class ModuleJsonServletTest {
                         "jcr:primaryType", "pant:module")
                 .resource("/content/repositories/repo/module/en_US/variants/DEFAULT/released/metadata",
                         "jcr:title", "A title",
-                        "jcr:description", "A description")
+                        "jcr:description", "A description",
+                        "pant:abstract", "The abstract")
                 .resource("/content/repositories/repo/module/en_US/source/released/jcr:content",
                         "jcr:data", "This is the source content")
                 .resource("/content/repositories/repo/module/en_US/variants/DEFAULT/released/cached_html/jcr:content",
@@ -97,7 +98,7 @@ class ModuleJsonServletTest {
         assertTrue(map.containsKey("module"));
         assertTrue(moduleMap.containsKey("module_uuid"));
         assertTrue(moduleMap.containsKey("products"));
-        assertTrue(moduleMap.containsKey("description"));
+        assertEquals("The abstract", moduleMap.get("description"));
         assertTrue(moduleMap.containsKey("locale"));
         assertTrue(moduleMap.containsKey("title"));
         assertTrue(moduleMap.containsKey("body"));


### PR DESCRIPTION
As a result the extracted abstract from the module content will be returned in the description field of the module API.