### PR TITLE
CCS-3780: "Included in guides" API

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -183,7 +183,7 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
         //get the assemblies and iterate over them
 
-        helper.query("/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(released/content/*/@pant:moduleUuid='"+moduleVariant.getParent().getParent().getParent().uuid().get()+"')]"
+        helper.query("/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(released/content/*/@pant:moduleVariantUuid='"+moduleVariant.uuid().get()+"')]"
                 ,1000L, 0L, Query.XPATH)
                 .forEach(a->setAssemblyData(a,includeAssemblies));
         variantMap.put("included_in_guides", includeAssemblies);

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -3,8 +3,10 @@ package com.redhat.pantheon.servlet.module;
 import com.google.common.base.Charsets;
 import com.ibm.icu.util.ULocale;
 import com.redhat.pantheon.html.Html;
+import com.redhat.pantheon.jcr.JcrQueryHelper;
 import com.redhat.pantheon.model.ProductVersion;
 import com.redhat.pantheon.model.api.FileResource;
+import com.redhat.pantheon.model.assembly.*;
 import com.redhat.pantheon.model.module.ModuleMetadata;
 import com.redhat.pantheon.model.module.ModuleVariant;
 import com.redhat.pantheon.model.module.ModuleVersion;
@@ -22,12 +24,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
 import javax.servlet.Servlet;
 import java.util.*;
 
 import static com.redhat.pantheon.conf.GlobalConfig.CONTENT_TYPE;
 import static com.redhat.pantheon.model.api.util.ResourceTraversal.traverseFrom;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.apache.sling.query.SlingQuery.$;
 
 @Component(
         service = Servlet.class,
@@ -46,7 +50,8 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
     public static final String SEARCH_KEYWORDS = "search_keywords";
     public static final String VIEW_URI = "view_uri";
     public static final String PORTAL_URL = "PORTAL_URL";
-
+    public static final String PANTHEON_HOST = "PANTHEON_HOST";
+    public static final String ASSEMBLY_VARIANT_API_PATH = "/api/assembly/variant.json";
     private final Logger log = LoggerFactory.getLogger(VariantJsonServlet.class);
 
     private final SlingPathSuffix suffix = new SlingPathSuffix("/{variantUuid}");
@@ -90,6 +95,7 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
         Map<String, Object> variantMap = super.resourceToMap(request, resource);
         Map<String, Object> variantDetails = new HashMap<>();
+        JcrQueryHelper helper = new JcrQueryHelper(request.getResourceResolver());
 
         variantDetails.put("status", SC_OK);
         variantDetails.put("message", "Module Found");
@@ -173,7 +179,14 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
         else {
             variantMap.put(VIEW_URI, "");
         }
+        List<HashMap<String, String>>includeAssemblies = new ArrayList<>();
 
+        //get the assemblies and iterate over them
+
+        helper.query("/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(released/content/*/@pant:moduleUuid='"+moduleVariant.getParent().getParent().getParent().uuid().get()+"')]"
+                ,1000L, 0L, Query.XPATH)
+                .forEach(a->setAssemblyData(a,includeAssemblies));
+        variantMap.put("included_in_guides", includeAssemblies);
         // remove unnecessary fields from the map
         variantMap.remove("jcr:lastModified");
         variantMap.remove("jcr:lastModifiedBy");
@@ -187,6 +200,28 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
         return variantDetails;
     }
+
+    private void setAssemblyData(Resource resource, List<HashMap<String, String>> includeAssemblies) {
+        AssemblyVariant assemblyVariant = resource.adaptTo(AssemblyVariant.class);
+        HashMap<String,String> assemblyVariantDetails = new HashMap<>();
+
+        Optional<AssemblyMetadata> releasedMetadata = traverseFrom(assemblyVariant)
+                .toChild(AssemblyVariant::released)
+                .toChild(AssemblyVersion::metadata)
+                .getAsOptional();
+        assemblyVariantDetails.put("uuid", assemblyVariant.uuid().get());
+        assemblyVariantDetails.put("title", releasedMetadata.get().title().get());
+        if(assemblyVariant.released().isPresent()&& System.getenv(PANTHEON_HOST) != null){
+            String assemblyUrl = System.getenv(PANTHEON_HOST)
+                    + ASSEMBLY_VARIANT_API_PATH
+                    + "/"
+                    + assemblyVariant.uuid().get();
+            assemblyVariantDetails.put("url", assemblyUrl);
+        }
+        includeAssemblies.add(assemblyVariantDetails);
+
+    }
+
 
     private String sanitizeSuffix( String suffix) {
         // b537ef3c-5c7d-4280-91ce-e7e818e6cc11&proxyHost=<SOMEHOST>&proxyPort=8080&throwExceptionOnFailure=false


### PR DESCRIPTION
First iteration of the API.
It
1. Queries using the following XPath to get Assembly variants
`"/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(released/content/*/@pant:moduleUuid='<uuid>')]"`
2. Iterates over the results and with each resource:
     - Adapt to AssemblyVariant
     - Get the Id
     - Construct the url
     - Get the title
     