### PR TITLE
Ccs 3703 schema support

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServlet.java
@@ -177,6 +177,7 @@ public class AssemblyVariantJsonServlet extends AbstractJsonSingleQueryServlet {
         }
 
         List<Map> moduleList = new ArrayList<>();
+        List<Map<String, String>> publishedModuleList = new ArrayList<>();
         variantMap.put("modules_included", moduleList);
 
         AssemblyContent assemblyContent = assemblyVariant.released().get().content().get();
@@ -209,6 +210,14 @@ public class AssemblyVariantJsonServlet extends AbstractJsonSingleQueryServlet {
                         childResource.getValueMap().containsKey("pant:leveloffset") ? childResource.getValueMap().get("pant:leveloffset").toString() : "");
 
             }
+            for (Map<String, String> entry: moduleList) {
+                for (String key : entry.keySet()) {
+                    if (key == "module_url" && !entry.get(key).isEmpty()) {
+                        publishedModuleList.add(entry);
+                    }
+                }
+            }
+            variantMap.put("hasPart", publishedModuleList);
         }
         // remove unnecessary fields from the map
         variantMap.remove("jcr:lastModified");

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -194,6 +194,7 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
                 ,1000L, 0L, Query.XPATH)
                 .forEach(a->setAssemblyData(a,includeAssemblies));
         variantMap.put("included_in_guides", includeAssemblies);
+        variantMap.put("isPartOf", includeAssemblies);
         // remove unnecessary fields from the map
         variantMap.remove("jcr:lastModified");
         variantMap.remove("jcr:lastModifiedBy");

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServletTest.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.servlet.assembly;
 
 import com.redhat.pantheon.model.assembly.Assembly;
 import com.redhat.pantheon.model.assembly.AssemblyVariant;
+import com.redhat.pantheon.model.module.ModuleVariant;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
@@ -19,6 +20,7 @@ import java.util.Map;
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({SlingContextExtension.class})
 class AssemblyVariantJsonServletTest {
@@ -115,8 +117,17 @@ class AssemblyVariantJsonServletTest {
                         "jcr:data", "This is the source content")
                 .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/cached_html/jcr:content",
                         "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/module/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:moduleVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/content/0",
+                        "jcr:moduleVariantUuid", slingContext.resourceResolver()
+                                .getResource("/content/repositories/rhel-8-docs/entities/module/en_US/variants/DEFAULT")
+                                .getValueMap()
+                                .get("jcr:uuid")
+                                .toString())
                 .commit();
         registerMockAdapter(AssemblyVariant.class, slingContext);
+        registerMockAdapter(ModuleVariant.class, slingContext);
         AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
         slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
 
@@ -128,5 +139,19 @@ class AssemblyVariantJsonServletTest {
 
         //Then
         assertTrue(assemblyMap.containsKey("view_uri"));
+        assertTrue(assemblyMap.containsKey("uuid"));
+        assertTrue(assemblyMap.containsKey("products"));
+        assertTrue(assemblyMap.containsKey("description"));
+        assertTrue(assemblyMap.containsKey("locale"));
+        assertTrue(assemblyMap.containsKey("title"));
+        assertTrue(assemblyMap.containsKey("body"));
+        assertTrue(assemblyMap.containsKey("content_type"));
+        assertTrue(assemblyMap.containsKey("date_modified"));
+        assertTrue(assemblyMap.containsKey("date_published"));
+        assertTrue(assemblyMap.containsKey("status"));
+        assertTrue(assemblyMap.containsKey("modules_included"));
+        assertTrue(assemblyMap.containsKey("hasPart"));
+        assertEquals((map.get("status")), SC_OK);
+
     }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
@@ -112,6 +112,7 @@ public class VariantJsonServletTest {
         assertTrue(moduleMap.containsKey("revision_id"));
         assertTrue(moduleMap.containsKey("context_url_fragment"));
         assertTrue(moduleMap.containsKey("included_in_guides"));
+        assertTrue(moduleMap.containsKey("isPartOf"));
         assertEquals((map.get("message")), "Module Found");
         assertEquals((map.get("status")), SC_OK);
     }


### PR DESCRIPTION
This PR introduces the following changes:
* On module variant API, you will see "isPartOf" and the assembly/assemblies uuid and url that this module is included in
* On assembly variant API, you will see "hasPart" and the published module(s) info that this assembly includes