### PR TITLE
Minor refactorings

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/Content.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/Content.java
@@ -2,6 +2,7 @@ package com.redhat.pantheon.model;
 
 import com.redhat.pantheon.model.api.*;
 import com.redhat.pantheon.model.module.ModuleVersion;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 
 import javax.inject.Named;
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/EnumFieldImpl.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/EnumFieldImpl.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
  *
  * @author Carlos Munoz
  */
-public class EnumFieldImpl<T extends Enum> extends FieldImpl<T> {
+public class EnumFieldImpl<T extends Enum<T>> extends FieldImpl<T> {
 
     private final SlingModel owner;
 
@@ -21,15 +21,15 @@ public class EnumFieldImpl<T extends Enum> extends FieldImpl<T> {
 
     @Override
     public void set(@Nullable T value) {
-        new FieldImpl<>(getName(), String.class, owner).set( value == null ? null : value.name() );
+        owner.field(getName(), String.class).set( value == null ? null : value.name() );
     }
 
     @Override
     public T get() {
-        FieldImpl<String> fieldImpl = new FieldImpl<>(getName(), String.class, owner);
-        if(fieldImpl.get() == null) {
+        Field<String> field = owner.field(getName(), String.class);
+        if(field.get() == null) {
             return null;
         }
-        return (T)Enum.valueOf(getType(), fieldImpl.get());
+        return (T)Enum.valueOf(getType(), field.get());
     }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ResourceDecorator.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ResourceDecorator.java
@@ -32,7 +32,16 @@ public class ResourceDecorator implements SlingModel {
 
     @Override
     public <T> Field<T> field(String name, Class<T> type) {
+        if(type.isEnum()) {
+            // NOTE: This is some ugly casting magic so that the method is able to
+            // return the right types
+            return (Field<T>) enumField(name, (Class<? extends Enum>)type);
+        }
         return new FieldImpl<>(name, type, this);
+    }
+
+    private Field<? extends Enum> enumField(String name, Class<? extends Enum> type) {
+        return new EnumFieldImpl<>(name, type, this);
     }
 
     @Override

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ResourceDecorator.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/ResourceDecorator.java
@@ -36,12 +36,17 @@ public class ResourceDecorator implements SlingModel {
     }
 
     @Override
+    public <T extends SlingModel> Reference<T> reference(String name, Class<T> type) {
+        return new ReferenceFieldImpl<>(name, type, this);
+    }
+
+    @Override
     public void delete() throws PersistenceException {
         wrapped.getResourceResolver().delete(this);
     }
 
     /*
-     * The methods below are all delgate methods around the wrapped resource
+     * The methods below are all delegate methods around the wrapped resource
      * to make sure SlingResource conforms to the Resource interface.
      */
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingModel.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingModel.java
@@ -30,6 +30,15 @@ public interface SlingModel extends Resource {
     <T> Field<T> field(String name, Class<T> type);
 
     /**
+     * Returns a {@link Reference} field from this model object
+     * @param name The name of the reference field
+     * @param type The model type of the Resource being referenced by this field
+     * @param <T>
+     * @return The {@link Reference} object
+     */
+    <T extends SlingModel> Reference<T> reference(String name, Class<T> type);
+
+    /**
      * Deletes this resource from the repository.
      * @throws PersistenceException If there was a problem deleting the node, such as a failed constraing validation
      */

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingResourceProxy.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingResourceProxy.java
@@ -1,6 +1,6 @@
 package com.redhat.pantheon.model.api;
 
-import com.redhat.pantheon.util.function.Memoizer;
+import com.redhat.pantheon.model.api.util.Memoizer;
 import org.apache.sling.api.resource.Resource;
 
 import javax.inject.Named;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingResourceProxy.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/SlingResourceProxy.java
@@ -30,7 +30,6 @@ class SlingResourceProxy extends ResourceDecorator implements InvocationHandler 
 
     private enum MethodType {
         DefaultInterfaceMethod,
-        EnumFieldAccessor,
         FieldAccessor,
         ChildAccessor,
         ReferenceFieldAccessor,
@@ -63,12 +62,6 @@ class SlingResourceProxy extends ResourceDecorator implements InvocationHandler 
                         .invokeWithArguments(args);
             }
 
-            case EnumFieldAccessor: {
-                String fieldName = extractFieldName(method);
-                Class fieldType = extractParameterizedReturnType(method);
-                return new EnumFieldImpl(fieldName, fieldType, this);
-            }
-
             case FieldAccessor: {
                 String fieldName = extractFieldName(method);
                 Class fieldType = extractParameterizedReturnType(method);
@@ -94,10 +87,6 @@ class SlingResourceProxy extends ResourceDecorator implements InvocationHandler 
             default:
                 return method.invoke(this, args);
         }
-    }
-
-    private static boolean isEnumFieldAccessor(Method method) {
-        return isFieldAccessor(method) && Enum.class.isAssignableFrom(extractParameterizedReturnType(method));
     }
 
     private static boolean isChildAccessor(Method method) {
@@ -143,10 +132,6 @@ class SlingResourceProxy extends ResourceDecorator implements InvocationHandler 
         // (default methods declared in the SlingModel interface themselves)
         if( method.isDefault() ) {
             return MethodType.DefaultInterfaceMethod;
-        }
-        // methods which access an enum Field
-        else if( isEnumFieldAccessor(method) ) {
-            return MethodType.EnumFieldAccessor;
         }
         // methods which access a Field
         else if( isFieldAccessor(method) ) {

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/Memoizer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/api/util/Memoizer.java
@@ -1,4 +1,4 @@
-package com.redhat.pantheon.util.function;
+package com.redhat.pantheon.model.api.util;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/assembly/AssemblyPage.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/assembly/AssemblyPage.java
@@ -4,9 +4,8 @@ import com.redhat.pantheon.model.api.Child;
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.FileResource;
 import com.redhat.pantheon.model.api.Reference;
-import com.redhat.pantheon.model.api.WorkspaceChild;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
-import com.redhat.pantheon.model.module.Module;
 import com.redhat.pantheon.model.module.ModuleVariant;
 
 import javax.inject.Named;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/AckStatus.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/AckStatus.java
@@ -7,7 +7,7 @@ import javax.inject.Named;
 import org.apache.jackrabbit.JcrConstants;
 
 import com.redhat.pantheon.model.api.Field;
-import com.redhat.pantheon.model.api.WorkspaceChild;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
 
 @JcrPrimaryType("pant:acknowledgment")

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/Document.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/Document.java
@@ -3,7 +3,7 @@ package com.redhat.pantheon.model.document;
 import com.redhat.pantheon.model.api.Child;
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.FileResource;
-import com.redhat.pantheon.model.api.WorkspaceChild;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 
 import javax.annotation.Nonnull;
 import javax.inject.Named;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentLocale.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentLocale.java
@@ -1,7 +1,7 @@
 package com.redhat.pantheon.model.document;
 
 import com.redhat.pantheon.model.api.Child;
-import com.redhat.pantheon.model.api.WorkspaceChild;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 
 public interface DocumentLocale extends WorkspaceChild {
     Child<SourceContent> source();

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentMetadata.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentMetadata.java
@@ -3,8 +3,7 @@ package com.redhat.pantheon.model.document;
 import com.redhat.pantheon.model.ProductVersion;
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.Reference;
-import com.redhat.pantheon.model.api.SlingModel;
-import com.redhat.pantheon.model.api.WorkspaceChild;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 import org.apache.jackrabbit.JcrConstants;
 
 import javax.inject.Named;

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVariant.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVariant.java
@@ -1,25 +1,18 @@
 package com.redhat.pantheon.model.document;
 
-import com.redhat.pantheon.jcr.JcrResources;
 import com.redhat.pantheon.model.api.Child;
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.SlingModels;
-import com.redhat.pantheon.model.api.WorkspaceChild;
-import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
-import com.redhat.pantheon.model.api.Reference;
-import com.redhat.pantheon.model.api.SlingModel;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.api.resource.Resource;
 
 import javax.inject.Named;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import java.util.Calendar;
 
 import static com.google.common.collect.Streams.stream;
 import static com.redhat.pantheon.jcr.JcrResources.rename;
-import static java.util.stream.Collectors.counting;
 
 /**
  * A specific Document variant node which houses all the versions for a specific language in the Document.

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVersion.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVersion.java
@@ -4,10 +4,7 @@ import com.redhat.pantheon.model.api.Child;
 import com.redhat.pantheon.model.api.Field;
 import com.redhat.pantheon.model.api.FileResource;
 import com.redhat.pantheon.model.api.SlingModel;
-import com.redhat.pantheon.model.api.SlingModels;
-import com.redhat.pantheon.model.api.WorkspaceChild;
-import com.redhat.pantheon.model.api.annotation.JcrPrimaryType;
-import org.apache.sling.api.resource.Resource;
+import com.redhat.pantheon.model.workspace.WorkspaceChild;
 
 import javax.inject.Named;
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/ModuleMetadata.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/module/ModuleMetadata.java
@@ -1,15 +1,9 @@
 package com.redhat.pantheon.model.module;
 
-import com.redhat.pantheon.model.ProductVersion;
 import com.redhat.pantheon.model.api.Field;
-import com.redhat.pantheon.model.api.Reference;
-import com.redhat.pantheon.model.api.SlingModel;
-import com.redhat.pantheon.model.api.WorkspaceChild;
 import com.redhat.pantheon.model.document.DocumentMetadata;
-import org.apache.jackrabbit.JcrConstants;
 
 import javax.inject.Named;
-import java.util.Calendar;
 
 /**
  * Models an instance of metadata for a module. Multiple metadata

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/WorkspaceChild.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/workspace/WorkspaceChild.java
@@ -1,6 +1,6 @@
-package com.redhat.pantheon.model.api;
+package com.redhat.pantheon.model.workspace;
 
-import com.redhat.pantheon.model.workspace.Workspace;
+import com.redhat.pantheon.model.api.SlingModel;
 import org.apache.sling.api.resource.Resource;
 
 public interface WorkspaceChild extends SlingModel {

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/SlingModelsTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/model/api/SlingModelsTest.java
@@ -72,6 +72,7 @@ class SlingModelsTest {
         assertEquals(new Long(20), model.longField().get());
         assertArrayEquals(arrayValue, model.stringArrayField().get());
         assertEquals(TestResource.Value.VALUE_2, model.enumField().get());
+        assertEquals(TestResource.Value.VALUE_2.name(), model.field("enumField", String.class).get());
     }
 
     @Test
@@ -101,6 +102,7 @@ class SlingModelsTest {
         assertEquals(new Long(20), model.longField().get());
         assertArrayEquals(arrayValue, model.stringArrayField().get());
         assertEquals(TestResource.Value.VALUE_2, model.enumField().get());
+        assertEquals(TestResource.Value.VALUE_2.name(), model.field("enumField", String.class).get());
     }
 
     @Test


### PR DESCRIPTION
This change alters the internal structure of the model object framework **without** changing the development API.

Changes include:
- Move all classes needed by the framework into the `model.api`package so it's self-contained.
- Simplify the resource proxy logic by eliminating a single logical path when translating method invocations.
- Move the `WorkspaceChild` class outside of the api package as it is a business class and not a framework one.
- Other minor refactorings.