### PR TITLE
CCS-3785: error on git import when "Repository URL is invalid" needs to change on Pantheon UI

### DIFF
--- a/pantheon-bundle/frontend/src/app/gitImport.tsx
+++ b/pantheon-bundle/frontend/src/app/gitImport.tsx
@@ -119,7 +119,7 @@ class GitImport extends Component {
                     } else if (response.status === 500) {
                       console.log(" Failed " + response.status)
                       response.text().then((text) => {
-                        this.setState({ submitMsg: text })
+                        this.setState({ submitMsg: JSON.parse(text).error })
                       });
                     } else {
                       this.setState({ isSucess: false, msgType: "danger", submitMsg: "The git import submission has failed." })

--- a/tools/git2pantheon/main.go
+++ b/tools/git2pantheon/main.go
@@ -26,7 +26,7 @@ func cloneBranch(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		if err != nil {
-			http.Error(w, "Error reading request body",
+			http.Error(w, "{\"error\" : \"Error reading request body\"} ",
 				http.StatusInternalServerError)
 		}
 


### PR DESCRIPTION
This PR
1. Parses the exception message coming from Git2Pantheon
2. Makes one of the left out error message into standard JSON error format.