### PR TITLE
Reintroducing Wes' tweak to haml for anchors

### DIFF
--- a/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
+++ b/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
@@ -51,7 +51,7 @@
         };
       %script(src="https://access.redhat.com/webassets/avalon/j/lib/require.js")
       :javascript
-        chrometwo_require(["wc"], wc => wc.include("cp-documentation/dist/cp-documentation.umd.min"));
+        chrometwo_require(["wc"], wc => wc.include("@cpelements/cp-documentation/dist/cp-documentation.umd.min"));
 
 
   %body{:id => @id, :class=>[doctype, 'pantheon-render', ((attr? :toc) && (attr? 'toc-placement', 'auto') ? "has-toc toc-#{attr 'toc-position', 'left'}" : nil)]}


### PR DESCRIPTION
This was supposed to be part of the original xref feature branch but somehow didn't make it into master.