### PR TITLE
mvn test issue fix

### DIFF
--- a/pantheon-karaf-feature/pom.xml
+++ b/pantheon-karaf-feature/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.karaf-configs</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>       


### PR DESCRIPTION
One of the poms was still referring to 0.1.1 rather than 0.1.0 which results in mvn test failing. This PR fixes that.