### PR TITLE
Ccs 3743 change module type fixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
@@ -67,9 +67,9 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       />
     </FormSelect>
     <FormSelect
-      aria-label="FormSelect ModuleType"
+      aria-label="FormSelect cType"
       className="small-margin"
-      id="moduleTypeForm"
+      id="contentTypeForm"
       isDisabled={false}
       isRequired={false}
       onBlur={[Function]}
@@ -151,10 +151,10 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       />
       <FormSelectOption
         isDisabled={false}
-        key="Module type"
-        label="Module type"
+        key="Content type"
+        label="Content type"
         required={false}
-        value="Module type"
+        value="Content type"
       />
     </FormSelect>
     <Button

--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchFilter.test.tsx.snap
@@ -151,10 +151,10 @@ exports[`SearchFilter tests should render default Search component 1`] = `
       />
       <FormSelectOption
         isDisabled={false}
-        key="Content type"
+        key="Module type"
         label="Content type"
         required={false}
-        value="Content type"
+        value="Module type"
       />
     </FormSelect>
     <Button

--- a/pantheon-bundle/frontend/src/app/searchFilter.test.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.test.tsx
@@ -50,11 +50,11 @@ describe('SearchFilter tests', () => {
   })
 
 
-  it('test onChangeModuleType function', () => {
+  it('test onChangeContentType function', () => {
     const wrapper = renderer.create(<SearchFilter {...props} />)
     const inst = wrapper.getInstance()
-    const spy = sinon.spy(inst, 'onChangeModuleType')
-    inst.onChangeModuleType("type")
+    const spy = sinon.spy(inst, 'onChangeContentType')
+    inst.onChangeContentType("type")
     sinon.assert.called(spy)
   })
 

--- a/pantheon-bundle/frontend/src/app/searchFilter.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.tsx
@@ -57,7 +57,7 @@ class SearchFilter extends Component<any, any> {
       { value: 'Uploaded date', label: 'Uploaded date', disabled: false },
       { value: 'Title', label: 'Title', disabled: false },
       { value: 'Updated date', label: 'Updated date', disabled: false },
-      { value: 'Content type', label: 'Content type', disabled: false }
+      { value: 'Module type', label: 'Content type', disabled: false }
     ]
 
 

--- a/pantheon-bundle/frontend/src/app/searchFilter.tsx
+++ b/pantheon-bundle/frontend/src/app/searchFilter.tsx
@@ -11,8 +11,8 @@ class SearchFilter extends Component<any, any> {
     this.state = {
       allProducts: [],
       chipGroups: [],
+      contentTypeValue: '',
       isSortedUp: true,
-      moduleTypeValue: '',
       productOptions: [
         { value: '', label: 'Select a Product', disabled: false },
       ],
@@ -57,7 +57,7 @@ class SearchFilter extends Component<any, any> {
       { value: 'Uploaded date', label: 'Uploaded date', disabled: false },
       { value: 'Title', label: 'Title', disabled: false },
       { value: 'Updated date', label: 'Updated date', disabled: false },
-      { value: 'Module type', label: 'Module type', disabled: false }
+      { value: 'Content type', label: 'Content type', disabled: false }
     ]
 
 
@@ -84,7 +84,7 @@ class SearchFilter extends Component<any, any> {
             ))}
           </FormSelect>
 
-          <FormSelect className="small-margin" value={this.state.moduleTypeValue} onChange={this.onChangeModuleType} aria-label="FormSelect ModuleType" id="moduleTypeForm">
+          <FormSelect className="small-margin" value={this.state.contentTypeValue} onChange={this.onChangeContentType} aria-label="FormSelect cType" id="contentTypeForm">
             {contentTypeItems.map((option) => (
               <FormSelectOption isDisabled={false} key={option.value} value={option.value} label={option.label} required={false} />
             ))}
@@ -220,8 +220,8 @@ class SearchFilter extends Component<any, any> {
       this.setQuery();
     });
   }
-  private onChangeModuleType = (moduleTypeValue) => {
-    this.setState({ moduleTypeValue }, () => {
+  private onChangeContentType = (contentTypeValue) => {
+    this.setState({ contentTypeValue }, () => {
       this.setQuery();
     });
   }
@@ -359,11 +359,11 @@ class SearchFilter extends Component<any, any> {
     }
 
     // Default is All and should not add to the filter.
-    if (this.state.moduleTypeValue.trim() !== "" && this.state.moduleTypeValue.trim() !== "All") {
+    if (this.state.contentTypeValue.trim() !== "" && this.state.contentTypeValue.trim() !== "All") {
       if (searchQuery.trim() !== "") {
         searchQuery += "&"
       }
-      searchQuery += "type=" + this.state.moduleTypeValue
+      searchQuery += "type=" + this.state.contentTypeValue
     }
 
     // Default key is Uploaded


### PR DESCRIPTION
This PR updates the label in the sort filter. It changes the label from  "Module type" to "Content type" so that it matches the column name. 