### PR TITLE
Ccs 3323 send assembly data

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/Events.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/Events.java
@@ -32,7 +32,8 @@ public class Events {
         this.jobManager = jobManager;
     }
 
-    public void fireEvent(Event evt, int delayInsecs) {
+    public void
+    fireEvent(Event evt, int delayInsecs) {
         final long delay = delayInsecs * 1000;
         final Date fireDate = new Date();
         fireDate.setTime(System.currentTimeMillis() + delay);

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/HydraIntegration.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/HydraIntegration.java
@@ -97,7 +97,13 @@ public class HydraIntegration implements EventProcessingExtension {
             return false;
         }
 
-        return ModuleVersionPublishStateEvent.class.isAssignableFrom(event.getClass());
+        if (ModuleVersionPublishStateEvent.class.isAssignableFrom(event.getClass())
+                || AssemblyVersionPublishStateEvent.class.isAssignableFrom(event.getClass())) {
+            return true;
+        } else {
+            return false;
+        }
+
     }
 
     /**
@@ -267,7 +273,7 @@ public class HydraIntegration implements EventProcessingExtension {
 
     private String getPortalGuideUri(AssemblyVersion assemblyVersion) throws RepositoryException {
         final String uriTemplate = System.getenv(PORTAL_URL)
-                    + "/documentation/${localeId}/guide/"
+                    + "/documentation/${localeId}/guide"
                     + "/${productUrlFragment}/${versionUrlFragment}"
                     + "/${variantUuid}";
 
@@ -314,8 +320,8 @@ public class HydraIntegration implements EventProcessingExtension {
             AssemblyVersionPublishStateEvent publishStateEvent = (AssemblyVersionPublishStateEvent) event;
             assemblyVersion = SlingModels.getModel(serviceResourceResolverProvider.getServiceResourceResolver(),
                     publishStateEvent.getAssemblyVersionPath(), AssemblyVersion.class);
-            eventValue = AssemblyVersionUnpublishedEvent.class.equals(event.getClass()) ? EVENT_PUBLISH_VALUE : EVENT_UNPUBLISH_VALUE;
-            idValue = AssemblyVersionPublishStateEvent.class.equals(event.getClass()) ? buildDocumentVersionUri(assemblyVersion) : "";
+            eventValue = AssemblyVersionPublishedEvent.class.equals(event.getClass()) ? EVENT_PUBLISH_VALUE : EVENT_UNPUBLISH_VALUE;
+            idValue = AssemblyVersionPublishedEvent.class.equals(event.getClass()) ? buildDocumentVersionUri(assemblyVersion) : "";
         } else {
             log.warn("[" + HydraIntegration.class.getSimpleName() + "] unhandled event type: " + event.getClass());
         }
@@ -340,8 +346,8 @@ public class HydraIntegration implements EventProcessingExtension {
                         + ID_KEY + "\":" + "\"" + idValue +"\","
                         + "\"" + EVENT_KEY + "\":" + "\"" + eventValue + "\","
                         + "\"" + URI_KEY + "\":" + "\"" + uriValue + "\"}";
-                log.info("[" + HydraIntegration.class.getSimpleName() + "] unpublish message: " + msg);
             }
+            log.info("[" + HydraIntegration.class.getSimpleName() + "] pantheon message: " + msg);
         } else {
             log.warn("[" + HydraIntegration.class.getSimpleName() + "] unhandled event type: " + event.getClass());
         }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/PublishDraftVersion.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/PublishDraftVersion.java
@@ -81,7 +81,7 @@ public class PublishDraftVersion extends AbstractPostOperation {
         logger.debug("Operation Publishing draft version started");
         String variant = getVariant(request);
         if (variant == null) {
-            response.setError(new ServletException("The 'variant' paramter is required."));
+            response.setError(new ServletException("The 'variant' parameter is required."));
             return;
         }
         long startTime = System.currentTimeMillis();

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServlet.java
@@ -116,9 +116,6 @@ public class AssemblyVariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Striping out the jcr: from key name
         String variant_uuid = (String) variantMap.remove("jcr:uuid");
-        variantMap.put("variant_uuid", variant_uuid);
-        // TODO: remove assembly_uuid after Hydra team releases UNIFIED-6570
-        variantMap.put("assembly_uuid", variant_uuid);
         variantMap.put("uuid", variant_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -119,6 +119,8 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
         // Striping out the jcr: from key name
         String variant_uuid = (String) variantMap.remove("jcr:uuid");
         variantMap.put("uuid", variant_uuid);
+        // TODO: remove variant_uuid when Customer Portal no longer consumes variant_uuid.
+        variantMap.put("variant_uuid", variant_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());
         variantMap.put("date_modified", dateModified.toInstant().toString());

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/VariantJsonServlet.java
@@ -118,10 +118,6 @@ public class VariantJsonServlet extends AbstractJsonSingleQueryServlet {
 
         // Striping out the jcr: from key name
         String variant_uuid = (String) variantMap.remove("jcr:uuid");
-        variantMap.put("variant_uuid", variant_uuid);
-        // TODO: remove module_uuid after Hydra team releases UNIFIED-6570
-        // TODO: This is deprecated, but left for backwards compatibility
-        variantMap.put("module_uuid", variant_uuid);
         variantMap.put("uuid", variant_uuid);
         // Convert date string to UTC
         Date dateModified = new Date(resource.getResourceMetadata().getModificationTime());

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/extension/EventsTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/extension/EventsTest.java
@@ -1,7 +1,9 @@
 package com.redhat.pantheon.extension;
 
 import com.redhat.pantheon.extension.events.assembly.AssemblyVersionPublishedEvent;
+import com.redhat.pantheon.extension.events.assembly.AssemblyVersionUnpublishedEvent;
 import com.redhat.pantheon.extension.events.module.ModuleVersionPublishedEvent;
+import com.redhat.pantheon.extension.events.module.ModuleVersionUnpublishedEvent;
 import com.redhat.pantheon.model.assembly.AssemblyVersion;
 import com.redhat.pantheon.model.module.ModuleVersion;
 import org.apache.sling.event.jobs.JobBuilder;
@@ -39,6 +41,24 @@ class EventsTest {
         verify(jobBuilder, times(1)).schedule();
         verify(jobManager, times(1)).createJob(eq(Events.EVENT_TOPIC_NAME));
     }
+
+    @Test
+    void fireModuleVersionUnpublishEvent() {
+        // Given
+        Events events = new Events(jobManager);
+        JobBuilder jobBuilder = mock(JobBuilder.class, RETURNS_MOCKS);
+        lenient().when(jobManager.createJob(anyString())).thenReturn(jobBuilder);
+        lenient().when(jobBuilder.properties(anyMap())).thenReturn(jobBuilder);
+
+        // When
+        events.fireEvent(new ModuleVersionUnpublishedEvent(mock(ModuleVersion.class)), 15);
+
+        // Then
+        verify(jobBuilder, times(1)).properties(anyMap());
+        verify(jobBuilder, times(1)).schedule();
+        verify(jobManager, times(1)).createJob(eq(Events.EVENT_TOPIC_NAME));
+    }
+
     @Test
     void fireAssemblyVersionPublishedEvent() {
         // Given
@@ -49,6 +69,23 @@ class EventsTest {
 
         // When
         events.fireEvent(new AssemblyVersionPublishedEvent(mock(AssemblyVersion.class)), 15);
+
+        // Then
+        verify(jobBuilder, times(1)).properties(anyMap());
+        verify(jobBuilder, times(1)).schedule();
+        verify(jobManager, times(1)).createJob(eq(Events.EVENT_TOPIC_NAME));
+    }
+
+    @Test
+    void fireAssemblyVersionUnpublishEvent() {
+        // Given
+        Events events = new Events(jobManager);
+        JobBuilder jobBuilder = mock(JobBuilder.class, RETURNS_MOCKS);
+        lenient().when(jobManager.createJob(anyString())).thenReturn(jobBuilder);
+        lenient().when(jobBuilder.properties(anyMap())).thenReturn(jobBuilder);
+
+        // When
+        events.fireEvent(new AssemblyVersionUnpublishedEvent(mock(AssemblyVersion.class)), 15);
 
         // Then
         verify(jobBuilder, times(1)).properties(anyMap());

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/assembly/AssemblyVariantJsonServletTest.java
@@ -83,7 +83,6 @@ class AssemblyVariantJsonServletTest {
         assertTrue(map.containsKey("status"));
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("assembly"));
-        assertTrue(assemblyMap.containsKey("assembly_uuid"));
         assertTrue(assemblyMap.containsKey("products"));
         assertTrue(assemblyMap.containsKey("locale"));
         assertTrue(assemblyMap.containsKey("title"));

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/module/VariantJsonServletTest.java
@@ -94,9 +94,7 @@ public class VariantJsonServletTest {
         assertTrue(map.containsKey("status"));
         assertTrue(map.containsKey("message"));
         assertTrue(map.containsKey("module"));
-        // TODO Remove this check when module_uuid is removed
         assertTrue(moduleMap.containsKey("uuid"));
-        assertTrue(moduleMap.containsKey("variant_uuid"));
         assertTrue(moduleMap.containsKey("products"));
         assertTrue(moduleMap.containsKey("description"));
         assertTrue(moduleMap.containsKey("locale"));


### PR DESCRIPTION
This PR introduces the following changes:
   * remove deprecated "module_uuid", "variant_uuid" and "assembly_uuid" from module/assembly variant apis. Going forward, we will only have "uuid". Hydra team is aware of this action. They are going to prod with this change tomorrow.
   * Update HydraIntegration to allow messages to be sent to Hydra when we publish/unpublish Assembly