### PR TITLE
 CCS-3480: Show assemblies on module detail page

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/moduleDisplay.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/moduleDisplay.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`ModuleDisplay tests should render ModuleDisplay component 1`] = `
   <br />
   <Card>
     <Versions
+      assemblies={Array []}
       attributesFilePath=""
       contentType="module"
       modulePath=""

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -216,7 +216,7 @@ class ModuleDisplay extends Component<any, any, any> {
         fetch(path + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
-                 console.log('fetch results:', responseJSON)
+                 // console.log('fetch results:', responseJSON)
                 // TODO: refactor for loops
                 for (const sourceVariant of responseJSON.__children__) {
                     if (!sourceVariant.__children__) {
@@ -411,7 +411,6 @@ class ModuleDisplay extends Component<any, any, any> {
     }
 
     private fetchIncludedInAssembliesDetails =  (data) => {
-        console.log('data='+data)
         fetch('/module/assemblies.json/'+data)
             .then((response) => {
                 if (response.ok) {

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -30,7 +30,10 @@ class ModuleDisplay extends Component<any, any, any> {
             results: {},
             variant: 'DEFAULT',
             variantUUID: '',
-            versionValue: ""
+            versionValue: "",
+            assemblyData: [],
+            assemblyTitle: "",
+            assemblyPath: ""
         }
     }
 
@@ -39,6 +42,7 @@ class ModuleDisplay extends Component<any, any, any> {
         this.getVersionUUID(this.props.location.pathname)
         this.getPortalUrl()
         this.fetchAttributesFilePath(this.props)
+
     }
 
     public render() {
@@ -174,6 +178,7 @@ class ModuleDisplay extends Component<any, any, any> {
                         variant={this.state.variant}
                         variantUUID={this.state.variantUUID}
                         attributesFilePath={this.state.attributesFilePath}
+                        assemblies={this.state.assemblyData}
                         updateDate={this.updateDate}
                         onGetProduct={this.getProduct}
                         onGetVersion={this.getVersion}
@@ -211,7 +216,7 @@ class ModuleDisplay extends Component<any, any, any> {
         fetch(path + '/en_US.harray.4.json')
             .then(response => response.json())
             .then(responseJSON => {
-                // console.log('fetch results:', responseJSON)
+                 console.log('fetch results:', responseJSON)
                 // TODO: refactor for loops
                 for (const sourceVariant of responseJSON.__children__) {
                     if (!sourceVariant.__children__) {
@@ -226,6 +231,7 @@ class ModuleDisplay extends Component<any, any, any> {
 
                             this.setState({ draftUpdateDate: myChild["jcr:created"] })
                         }
+
                         for (const myGrandchild of myChild.__children__) {
                             if (!myGrandchild.__children__) {
                                 continue
@@ -250,6 +256,15 @@ class ModuleDisplay extends Component<any, any, any> {
                                 }
                             }
 
+                        }
+                    }
+
+                }
+                // get the variant UUID
+                for (const variants of responseJSON.__children__){
+                    if(variants.__name__ === 'variants'){
+                        for (const variant of variants.__children__){
+                            this.fetchIncludedInAssembliesDetails(variant[Fields.JCR_UUID])
                         }
                     }
                 }
@@ -393,6 +408,23 @@ class ModuleDisplay extends Component<any, any, any> {
             .catch((error) => {
                 console.log(error)
             })
+    }
+
+    private fetchIncludedInAssembliesDetails =  (data) => {
+        console.log('data='+data)
+        fetch('/module/assemblies.json/'+data)
+            .then((response) => {
+                if (response.ok) {
+                    return response.json()
+                }else {
+                    throw new Error(response.statusText)
+                }
+            })
+            .then(responseJSON => {
+                    this.setState({assemblyData: responseJSON.assemblies})
+                }
+
+            )
     }
 
 }

--- a/pantheon-bundle/frontend/src/app/versions.test.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.test.tsx
@@ -14,6 +14,7 @@ import { any } from 'prop-types';
 const anymatch = require('anymatch')
 
 const props = {
+    assemblies: [],
     attributesFilePath: "/repositories/testRepo/attributes.adoc",
     contentType: "module",
     modulePath: "/modules/test",

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -106,10 +106,6 @@ class Versions extends Component<IProps, IState> {
     }
 
     public componentDidUpdate(prevProps) {
-       // if(this.props.assemblies){
-       //     this.setState({assemblyData: this.props.assemblies})
-       // }
-        console.log('in version='+this.props.assemblies)
         if (this.props.modulePath !== prevProps.modulePath) {
             this.fetchVersions()
         }

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -1,5 +1,16 @@
 import React, { Component } from 'react'
-import { Button, Level, LevelItem, Text, TextContent, TextVariants, CardHeaderMain, CardActions, Tooltip } from '@patternfly/react-core'
+import {
+    Button,
+    Level,
+    LevelItem,
+    Text,
+    TextContent,
+    TextVariants,
+    CardHeaderMain,
+    CardActions,
+    Tooltip,
+    TextList, TextListItem, TextListVariants, TextListItemVariants
+} from '@patternfly/react-core'
 import {
     Alert, AlertActionCloseButton, BaseSizes, Card, CardHeader, CardBody,
     Form, FormGroup, FormSelect, FormSelectOption, Grid, GridItem, InputGroup,
@@ -9,7 +20,7 @@ import CheckImage from '@app/images/check_image.jpg'
 import BlankImage from '@app/images/blank.jpg'
 import { Redirect } from 'react-router-dom'
 import { ExclamationTriangleIcon, TimesIcon, PlusCircleIcon } from '@patternfly/react-icons'
-import { PantheonContentTypes } from './Constants'
+import {PantheonContentTypes, PathPrefixes} from './Constants'
 
 export interface IProps {
     contentType: string
@@ -19,6 +30,7 @@ export interface IProps {
     variant: string
     variantUUID: string
     attributesFilePath: string
+    assemblies?: any
     updateDate: (draftUpdateDate, releaseUpdateDate, releaseVersion, variantUUID) => any
     onGetProduct: (productValue) => any
     onGetVersion: (versionValue) => any
@@ -46,7 +58,8 @@ interface IState {
     showMetadataAlertIcon: boolean
     successAlertVisible: boolean
     usecaseOptions: any
-    usecaseValue: string,
+    usecaseValue: string
+    assemblyData: [],
 }
 
 class Versions extends Component<IProps, IState> {
@@ -82,6 +95,7 @@ class Versions extends Component<IProps, IState> {
                 { value: '', label: 'Select Use Case', disabled: false }
             ],
             usecaseValue: '',
+            assemblyData: [],
         }
     }
 
@@ -92,6 +106,10 @@ class Versions extends Component<IProps, IState> {
     }
 
     public componentDidUpdate(prevProps) {
+       // if(this.props.assemblies){
+       //     this.setState({assemblyData: this.props.assemblies})
+       // }
+        console.log('in version='+this.props.assemblies)
         if (this.props.modulePath !== prevProps.modulePath) {
             this.fetchVersions()
         }
@@ -195,12 +213,22 @@ class Versions extends Component<IProps, IState> {
                                             <TextContent>
                                                 {this.props.contentType === PantheonContentTypes.MODULE &&
                                                     <Text><strong>Assemblies</strong></Text>
+
                                                 }
 
                                                 {this.props.contentType === PantheonContentTypes.ASSEMBLY &&
                                                     <Text><strong>Modules</strong></Text>
                                                 }
-                                                <Text component={TextVariants.p}>{}</Text>
+                                            </TextContent>
+                                            <TextContent>
+                                                {this.props.assemblies&&this.props.assemblies.map(item=>(
+                                                    <TextList component={TextListVariants.ul}>
+                                                        <TextListItem component={TextListItemVariants.li}>
+                                                            <a href={'/pantheon/#/assembly'+item.path.substring("/content".length)+"?variant="+this.props.variant}> {item.title}</a>
+                                                        </TextListItem>
+                                                    </TextList>))
+
+                                                }
                                             </TextContent>
                                         </CardBody>
 
@@ -246,7 +274,17 @@ class Versions extends Component<IProps, IState> {
                                                     {this.props.contentType === PantheonContentTypes.ASSEMBLY &&
                                                         <Text><strong>Modules</strong></Text>
                                                     }
-                                                    <Text component={TextVariants.p}>{}</Text>
+
+                                                </TextContent>
+                                                <TextContent>
+                                                    {this.props.assemblies&&this.props.assemblies.map(item=>(
+                                                        <TextList component={TextListVariants.ul}>
+                                                            <TextListItem component={TextListItemVariants.li}>
+                                                                <a href={'/pantheon/#/assembly'+item.path.substring("/content".length)+"?variant="+this.props.variant}> {item.title}</a>
+                                                            </TextListItem>
+                                                        </TextList>))
+
+                                                    }
                                                 </TextContent>
                                             </CardBody>
 

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
@@ -109,7 +109,10 @@ public class ServletHelper {
     public static void setAssemblyData(Resource resource, List<HashMap<String, String>> includeAssemblies, boolean addPath, boolean canHaveDraft) {
         AssemblyVariant assemblyVariant = resource.adaptTo(AssemblyVariant.class);
         HashMap<String,String> assemblyVariantDetails = new HashMap<>();
-
+        // if draft version cannot be added, however only draft exists, then just return
+        if(!canHaveDraft&&assemblyVariant.hasDraft()){
+            return;
+        }
         Optional<AssemblyMetadata> metadata = traverseFrom(assemblyVariant)
                 .toChild(assemblyVariant.hasDraft()&&canHaveDraft?AssemblyVariant::draft:AssemblyVariant::released)
                 .toChild(AssemblyVersion::metadata)

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
@@ -1,21 +1,51 @@
 package com.redhat.pantheon.servlet.util;
 
+import com.redhat.pantheon.jcr.JcrQueryHelper;
+import com.redhat.pantheon.model.assembly.AssemblyMetadata;
+import com.redhat.pantheon.model.assembly.AssemblyVariant;
+import com.redhat.pantheon.model.assembly.AssemblyVersion;
+import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.ModuleVariant;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
 
+import static com.redhat.pantheon.model.api.util.ResourceTraversal.traverseFrom;
+
+/**
+ * The type Servlet helper.
+ */
 public class ServletHelper {
+    /**
+     * The constant PANTHEON_HOST.
+     */
+    public static final String PANTHEON_HOST = "PANTHEON_HOST";
+    /**
+     * The constant ASSEMBLY_VARIANT_API_PATH.
+     */
+    public static final String ASSEMBLY_VARIANT_API_PATH = "/api/assembly/variant.json";
 
+    /**
+     * Instantiates a new Servlet helper.
+     */
     public ServletHelper() {}
 
     /**
      * Returns a Resource given uuid
-     * @param uuid
+     *
+     * @param request the request
+     * @param uuid    the uuid
      * @return a Resource
-     * @throws RepositoryException
+     * @throws RepositoryException the repository exception
      */
     public static Resource getResourceByUuid(SlingHttpServletRequest request, String uuid) throws RepositoryException {
         Node foundNode = request.getResourceResolver()
@@ -27,5 +57,98 @@ public class ServletHelper {
                 .getResource(foundNode.getPath());
 
         return foundResource;
+    }
+
+    /**
+     * Add assembly details.
+     *
+     * @param moduleUuid        the module uuid
+     * @param includeAssemblies the container for assembly details
+     * @param request           the request
+     * @param addPath           whether or not to add the path of assembly to details
+     * @param canHaveDraft      can the draft version be included
+     * @throws RepositoryException the repository exception
+     */
+    public static void addAssemblyDetails(String moduleUuid, List<HashMap<String, String>> includeAssemblies,
+                                          SlingHttpServletRequest request, boolean addPath, boolean canHaveDraft) throws RepositoryException {
+        JcrQueryHelper helper = new JcrQueryHelper(request.getResourceResolver());
+        helper.query(getQueryForIncludedInAssemblies(moduleUuid,canHaveDraft)
+                ,1000L, 0L, Query.XPATH)
+                .forEach(a->setAssemblyData(a,includeAssemblies, addPath, canHaveDraft));
+    }
+
+    private static String getQueryForIncludedInAssemblies(String moduleUuid, boolean canHaveDraft) {
+        if(!canHaveDraft){
+           return  "/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(released/content/*/@pant:moduleUuid='" + moduleUuid + "')]";
+        }
+        return "/jcr:root/content/(repositories | assemblies | variants)//element(*, pant:assemblyVariant)[(*/content/*/@pant:moduleUuid='" + moduleUuid + "')]";
+    }
+
+    /**
+     * Gets module uuid from variant.
+     *
+     * @param moduleVariant the module variant
+     * @return the module uuid from variant
+     */
+    public static String getModuleUuidFromVariant(ModuleVariant moduleVariant) {
+         return moduleVariant
+                 .getParentLocale()
+                 .getParent()
+                 .uuid()
+                 .get();
+    }
+
+    /**
+     * Sets assembly data.
+     *
+     * @param resource          the resource representing an AssemblyVariant
+     * @param includeAssemblies the container for assembly details
+     * @param addPath           whether or not to add the path of assembly to details
+     * @param canHaveDraft      can the draft version be included
+     */
+    public static void setAssemblyData(Resource resource, List<HashMap<String, String>> includeAssemblies, boolean addPath, boolean canHaveDraft) {
+        AssemblyVariant assemblyVariant = resource.adaptTo(AssemblyVariant.class);
+        HashMap<String,String> assemblyVariantDetails = new HashMap<>();
+
+        Optional<AssemblyMetadata> releasedMetadata = traverseFrom(assemblyVariant)
+                .toChild(canHaveDraft?AssemblyVariant::draft:AssemblyVariant::released)
+                .toChild(AssemblyVersion::metadata)
+                .getAsOptional();
+        assemblyVariantDetails.put("uuid", assemblyVariant.uuid().get());
+        assemblyVariantDetails.put("title", releasedMetadata.get().title().get());
+        if(assemblyVariant.released().isPresent()&& System.getenv(PANTHEON_HOST) != null){
+            String assemblyUrl = System.getenv(PANTHEON_HOST)
+                    + ASSEMBLY_VARIANT_API_PATH
+                    + "/"
+                    + assemblyVariant.uuid().get();
+            assemblyVariantDetails.put("url", assemblyUrl);
+        }
+        if(addPath){
+            assemblyVariantDetails.put("path", assemblyVariant.getParentLocale().getParent().getPath());
+        }
+        includeAssemblies.add(assemblyVariantDetails);
+
+    }
+
+    /**
+     * Sanitize suffix string.
+     *
+     * @param suffix the suffix
+     * @return the string
+     */
+    public static String sanitizeSuffix( String suffix) {
+        // b537ef3c-5c7d-4280-91ce-e7e818e6cc11&proxyHost=<SOMEHOST>&proxyPort=8080&throwExceptionOnFailure=false
+
+        if(suffix.contains("&")) {
+            String parts[] = suffix.split("\\&");
+            suffix = parts[0];
+        }
+
+        if(suffix.contains("?")) {
+            String parts[] = suffix.split("\\?");
+            suffix = parts[0];
+        }
+
+        return suffix;
     }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
@@ -110,12 +110,12 @@ public class ServletHelper {
         AssemblyVariant assemblyVariant = resource.adaptTo(AssemblyVariant.class);
         HashMap<String,String> assemblyVariantDetails = new HashMap<>();
 
-        Optional<AssemblyMetadata> releasedMetadata = traverseFrom(assemblyVariant)
-                .toChild(canHaveDraft?AssemblyVariant::draft:AssemblyVariant::released)
+        Optional<AssemblyMetadata> metadata = traverseFrom(assemblyVariant)
+                .toChild(canHaveDraft&&assemblyVariant.hasDraft()?AssemblyVariant::draft:AssemblyVariant::released)
                 .toChild(AssemblyVersion::metadata)
                 .getAsOptional();
         assemblyVariantDetails.put("uuid", assemblyVariant.uuid().get());
-        assemblyVariantDetails.put("title", releasedMetadata.get().title().get());
+        assemblyVariantDetails.put("title", metadata.get().title().get());
         if(assemblyVariant.released().isPresent()&& System.getenv(PANTHEON_HOST) != null){
             String assemblyUrl = System.getenv(PANTHEON_HOST)
                     + ASSEMBLY_VARIANT_API_PATH

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
@@ -111,7 +111,7 @@ public class ServletHelper {
         HashMap<String,String> assemblyVariantDetails = new HashMap<>();
 
         Optional<AssemblyMetadata> metadata = traverseFrom(assemblyVariant)
-                .toChild(canHaveDraft&&assemblyVariant.hasDraft()?AssemblyVariant::draft:AssemblyVariant::released)
+                .toChild(assemblyVariant.hasDraft()&&canHaveDraft?AssemblyVariant::draft:AssemblyVariant::released)
                 .toChild(AssemblyVersion::metadata)
                 .getAsOptional();
         assemblyVariantDetails.put("uuid", assemblyVariant.uuid().get());

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
@@ -176,6 +176,36 @@ public class ServletHelperTest {
     }
 
     @Test
+    void setAssemblyDetailsTestDraftAndCannotHaveDraft() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes",
+                        "jcr:primaryType", "pant:assembly")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,false, false);
+        assertTrue(includeAssemblies.isEmpty(),"assembly details should  be empty ");
+    }
+    @Test
     public void getModuleUUIDFromVariant(){
         // Given
         slingContext.build()

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
@@ -1,6 +1,10 @@
 package com.redhat.pantheon.servlet.util;
 
+import com.google.common.collect.ImmutableMap;
+import com.redhat.pantheon.model.assembly.AssemblyVariant;
 import com.redhat.pantheon.model.module.Module;
+import com.redhat.pantheon.model.module.ModuleVariant;
+import com.redhat.pantheon.servlet.assembly.AssemblyVariantJsonServlet;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
@@ -11,8 +15,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.jcr.RepositoryException;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import static com.redhat.pantheon.util.TestUtils.registerMockAdapter;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Lisa Davidson
@@ -20,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith({SlingContextExtension.class})
 public class ServletHelperTest {
     SlingContext slingContext = new SlingContext(ResourceResolverType.JCR_OAK);
-
+    String testHTML = "<!DOCTYPE html> <html lang=\"en\"> <head><title>test title</title></head> <body " +
+            "class=\"article\"><h1>test title</h1> </header> </body> </html>";
     @Test
     void getResourceByUuidTest() throws RepositoryException {
         // Given
@@ -42,5 +51,150 @@ public class ServletHelperTest {
         // Then
         assertEquals("pantheon/module", resource.getResourceType());
         assertEquals("pant:module", resource.getValueMap().get("jcr:primaryType"));
+    }
+
+    @Test
+    void setAssemblyDetailsTest() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,false, false);
+        assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
+    }
+    @Test
+    void setAssemblyDetailsTestWithPath() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes",
+                        "jcr:primaryType", "pant:assembly")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,true, false);
+        assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
+        assertTrue(includeAssemblies.get(0).containsKey("path"));
+    }
+
+    @Test
+    void setAssemblyDetailsTestWithPathAndDraft() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes",
+                        "jcr:primaryType", "pant:assembly")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,true, true);
+        assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
+        assertTrue(includeAssemblies.get(0).containsKey("path"));
+    }
+
+    @Test
+    void setAssemblyDetailsTestWithoutPathAndDraft() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes",
+                        "jcr:primaryType", "pant:assembly")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,false, true);
+        assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
+        assertFalse(includeAssemblies.get(0).containsKey("path"));
+    }
+
+    @Test
+    public void getModuleUUIDFromVariant(){
+        // Given
+        slingContext.build()
+                .resource("/content/repositories/repo",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/repo/module","jcr:primaryType", "pant:moduleVersion")
+                .resource("/content/repositories/repo/module/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:moduleVariant")
+                .resource("/content/repositories/repo/module/en_US/variants/DEFAULT/released/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/repo/module/en_US/source/released/jcr:content",
+                        "jcr:data", "This is the source content")
+                .resource("/content/repositories/repo/module/en_US/variants/DEFAULT/released/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .commit();
+
+        registerMockAdapter(ModuleVariant.class, slingContext);
+        String uuid=  ServletHelper.getModuleUuidFromVariant(slingContext.resourceResolver().getResource("/content/repositories/repo/module/en_US/variants/DEFAULT").adaptTo(ModuleVariant.class));
+        assertNotNull(uuid, "module uuid should not be null");
     }
 }

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -21,7 +21,7 @@ cd $PANTHEON_CODEBASE
 set -e
 # build the distribution
 # build the karaf-features and karaf-config along with pantheon modules
-./mvnw clean install -U -e  -pl sling-org-apache-sling-karaf-features,sling-org-apache-sling-karaf-configs,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
+./mvnw clean install -U -pl sling-org-apache-sling-karaf-features,sling-org-apache-sling-karaf-configs,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
 pantheon-karaf-dist/target/assembly/bin/karaf
 set +e
 

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -21,7 +21,7 @@ cd $PANTHEON_CODEBASE
 set -e
 # build the distribution
 # build the karaf-features and karaf-config along with pantheon modules
-./mvnw clean install -U -pl sling-org-apache-sling-karaf-features,sling-org-apache-sling-karaf-configs,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
+./mvnw clean install -U -e  -pl sling-org-apache-sling-karaf-features,sling-org-apache-sling-karaf-configs,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
 pantheon-karaf-dist/target/assembly/bin/karaf
 set +e
 


### PR DESCRIPTION
This PR:

1. Introduces a new API endpoint /module/assemblies.json for retrieving list of assembly details corresponding to module variant uuid.
2. Refactors logic for retrieving list of assembly details corresponding to module into a set of utility methods.
3. Adds assembly list to the module details page where each assembly title links to assembly details page.