### PR TITLE
fix the incorrect encoding of a stream parameter when a character encoding is specified

### DIFF
--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -465,6 +465,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ServletUtils.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/ServletUtils.java
@@ -154,14 +154,11 @@ public final class ServletUtils {
                                             @Nonnull final String charsetEncoding,
                                             @Nonnull final Function<InputStream, R> handler)
             throws IOException {
-        return handleParamAsStream(request, paramName,
-                inputStream -> {
-                    try(ReaderInputStream ris = new ReaderInputStream(new InputStreamReader(inputStream), charsetEncoding)) {
-                        return handler.apply(ris);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+        ReaderInputStream ris;
+        try (InputStream stream = request.getRequestParameter(paramName).getInputStream()) {
+            ris = new ReaderInputStream(new InputStreamReader(stream), charsetEncoding);
+            return handler.apply(ris);
+        }
     }
 
     /**
@@ -179,11 +176,9 @@ public final class ServletUtils {
                                             @Nonnull final String paramName,
                                             @Nonnull final Function<InputStream, R> handler)
             throws IOException {
-        ReaderInputStream ris;
         try (InputStream stream = request.getRequestParameter(paramName).getInputStream()) {
-            ris = new ReaderInputStream(new InputStreamReader(stream), StandardCharsets.UTF_8);
+            return handler.apply(stream);
         }
-        return handler.apply(ris);
     }
 
     /**


### PR DESCRIPTION
This should fix the problem in #427 and still allow the api clients to use the encoding of their choice.