### PR TITLE
Reworking portal url handling

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/assemblyDisplay.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/assemblyDisplay.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`AssemblyDisplay tests should render AssemblyDisplay component 1`] = `
           onPublishEvent={[Function]}
           productInfo=""
           updateDate={[Function]}
-          variant={null}
+          variant="DEFAULT"
           variantUUID=""
           versionModulePath=""
         />

--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.test.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.test.tsx
@@ -126,7 +126,7 @@ describe("AssemblyDisplay tests", () => {
         wrapper.setState({ "login": true })
         wrapper.setState({ "releaseUpdateDate": "Fri Oct 18 2019 17:35:50 GMT-0400" })
         wrapper.setState({ "variantUUID": "123" })
-        wrapper.setState({ "portalHost": "https://example.com" })
+        wrapper.setState({ "portalUrl": "https://example.com" })
         const sourceTypeText = wrapper.find("a").at(0).text()
 
         // ensure it matches what is expected

--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
@@ -7,7 +7,26 @@ import { Versions } from "@app/versions"
 import { Fields, PathPrefixes, PantheonContentTypes } from "@app/Constants"
 // import { continueStatement } from "@babel/types";
 
-class AssemblyDisplay extends Component<any, any, any> {
+export interface IAssemblyDisplayState {
+        attributesFilePath: string
+        copySuccess: string
+        draftPath: string
+        draftUpdateDate: string
+        modulePath: string
+        moduleTitle: string
+        moduleType: string
+        portalUrl: string
+        productValue: string
+        releasePath: string
+        releaseUpdateDate: string
+        releaseVersion: string
+        results: any
+        variant: string
+        variantUUID: string
+        versionValue: string
+}
+
+class AssemblyDisplay extends Component<any, IAssemblyDisplayState> {
 
     constructor(props) {
         super(props)
@@ -19,10 +38,8 @@ class AssemblyDisplay extends Component<any, any, any> {
             modulePath: "",
             moduleTitle: "",
             moduleType: "",
-            portalHost: "",
+            portalUrl: "",
             productValue: "",
-            productUrlFragment: "",
-            versionUrlFragment: "",
             releasePath: "",
             releaseUpdateDate: "",
             releaseVersion: "",
@@ -36,7 +53,6 @@ class AssemblyDisplay extends Component<any, any, any> {
     public componentDidMount() {
         this.fetchModuleDetails(this.props)
         this.getVersionUUID(this.props.location.pathname)
-        this.getPortalUrl()
         this.fetchAttributesFilePath(this.props)
     }
 
@@ -70,14 +86,14 @@ class AssemblyDisplay extends Component<any, any, any> {
                         <LevelItem>
                             {this.state.releaseUpdateDate.trim() !== "" && this.state.releaseUpdateDate !== "-"
                                 && this.state.variantUUID !== ""
-                                && this.state.portalHost !== ""
-                                && <span><a href={this.state.portalHost + "/documentation/en-us/guide/" + this.state.productUrlFragment + "/" + this.state.versionUrlFragment + "/" + this.state.variantUUID} target="_blank">View on Customer Portal  <i className="fa pf-icon-arrow" /></a> </span>
+                                && this.state.portalUrl !== ""
+                                && <span><a href={this.state.portalUrl} target="_blank">View on Customer Portal  <i className="fa pf-icon-arrow" /></a> </span>
                             }
                         </LevelItem>
                         <LevelItem>
                             {this.state.releaseUpdateDate.trim() !== "" && this.state.releaseUpdateDate !== "-"
                                 && this.state.variantUUID !== ""
-                                && this.state.portalHost !== ""
+                                && this.state.portalUrl !== ""
                                 && <span><a id="permanentURL" onClick={this.copyToClipboard} onMouseLeave={this.mouseLeave}>Copy permanent URL  <CopyIcon /></a></span>
                             }
 
@@ -195,6 +211,8 @@ class AssemblyDisplay extends Component<any, any, any> {
             releasePath: "/content" + path + ".preview?variant=" + this.state.variant
         })
 
+        this.getPortalUrl(path, this.state.variant)
+
         fetch(path + "/en_US.harray.4.json")
             .then(response => response.json())
             .then(responseJSON => {
@@ -310,7 +328,7 @@ class AssemblyDisplay extends Component<any, any, any> {
                         if (productChild.__children__) {
                             for (const productVersion of productChild.__children__) {
                                 if (productVersion[Fields.JCR_UUID] === uuid) {
-                                    this.setState({ productValue: product.name, versionValue: productVersion.name, productUrlFragment: product.urlFragment, versionUrlFragment: productVersion.urlFragment })
+                                    this.setState({ productValue: product.name, versionValue: productVersion.name })
                                     break
                                 }
                             }
@@ -323,7 +341,7 @@ class AssemblyDisplay extends Component<any, any, any> {
     private copyToClipboard = () => {
         const textField = document.createElement("textarea")
         if (this.state.variantUUID.trim() !== "") {
-            textField.value = this.state.portalHost + "/documentation/en-us/guide/" + this.state.productUrlFragment + "/" + this.state.versionUrlFragment + "/" + this.state.variantUUID
+            textField.value = this.state.portalUrl
             document.body.appendChild(textField)
             textField.select()
             document.execCommand("copy")
@@ -336,13 +354,13 @@ class AssemblyDisplay extends Component<any, any, any> {
         this.setState({ copySuccess: "" })
     }
 
-    private getPortalUrl = () => {
-        fetch("/conf/pantheon/pant:portalUrl")
+    private getPortalUrl = (path, variant) => {
+        const variantPath = "/content" + path + "/en_US/variants/" + variant + ".url.txt"
+        fetch(variantPath)
             .then(resp => {
                 if (resp.ok) {
                     resp.text().then(text => {
-                        this.setState({ portalHost: text })
-                        // console.log("set portalHost: " + this.state.portalHost)
+                        this.setState({ portalUrl: text })
                     })
                 }
             })
@@ -351,8 +369,8 @@ class AssemblyDisplay extends Component<any, any, any> {
     private async getVariantParam() {
         const query = new URLSearchParams(this.props.location.search);
         const variantParam = query.get("variant")
-        // console.log("[getVariantparam] variantParam => ", variantParam)
-        if (variantParam !== "undefined") {
+        // console.log("[moduleDisplay] variantParam => "", variantParam)
+        if (variantParam !== "undefined" && variantParam !== null) {
             this.setState({ variant: variantParam })
         }
     }

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -21,8 +21,6 @@ export interface IModuleDisplayState {
     moduleType: string
     portalUrl: string
     productValue: string
-    productUrlFragment: string
-    versionUrlFragment: string
     releasePath: string
     releaseUpdateDate: string
     releaseVersion: string
@@ -46,8 +44,6 @@ class ModuleDisplay extends Component<any, IModuleDisplayState> {
             moduleType: "",
             portalUrl: "",
             productValue: "",
-            productUrlFragment: "",
-            versionUrlFragment: "",
             releasePath: "",
             releaseUpdateDate: "",
             releaseVersion: "",
@@ -362,7 +358,7 @@ class ModuleDisplay extends Component<any, IModuleDisplayState> {
                         if (productChild.__children__) {
                             for (const productVersion of productChild.__children__) {
                                 if (productVersion[Fields.JCR_UUID] === uuid) {
-                                    this.setState({ productValue: product.name, versionValue: productVersion.name, productUrlFragment: product.urlFragment, versionUrlFragment: productVersion.urlFragment })
+                                    this.setState({ productValue: product.name, versionValue: productVersion.name })
                                     break
                                 }
                             }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/url/CustomerPortalUrlProvider.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/extension/url/CustomerPortalUrlProvider.java
@@ -28,9 +28,6 @@ public abstract class CustomerPortalUrlProvider implements UrlProvider {
     }
 
     public String getHost(ResourceResolver resolver) {
-        Optional<Resource> conf = Optional.ofNullable(resolver.getResource("/conf/pantheon"));
-        return conf.map(Resource::getValueMap)
-                .map(m -> m.get("pant:portalUrl", String.class))
-                .orElse("");
+        return Optional.ofNullable(System.getenv("PORTAL_URL")).orElse("");
     }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/PantheonRepositoryInitializer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/sling/PantheonRepositoryInitializer.java
@@ -31,7 +31,6 @@ public class PantheonRepositoryInitializer implements SlingRepositoryInitializer
     @Override
     public void processRepository(SlingRepository slingRepository) throws Exception {
         setSyncServiceUrl();
-        setPortalUrl();
         setFrontEndRedirect();
     }
 
@@ -63,32 +62,10 @@ public class PantheonRepositoryInitializer implements SlingRepositoryInitializer
         }
     }
 
-    private void setPortalUrl() throws RepositoryException, PersistenceException {
-        try (ResourceResolver resourceResolver = serviceResourceResolverProvider.getServiceResourceResolver()) {
-            String portalUrl = getPortalUrl();
-            if (portalUrl != null) {
-                resourceResolver.getResource("/conf/pantheon")
-                        .adaptTo(ModifiableValueMap.class)
-                        .put("pant:portalUrl", portalUrl);
-                resourceResolver.commit();
-                log.info("Portal URL: " + portalUrl);
-            } else {
-                log.info("Environment Variable PORTAL_URL is not set.");
-            }
-        }
-    }
-
     /**
      * Retrieves the environment variable value for the sync service url
      */
     String getSyncServiceUrl() {
         return System.getenv("SYNC_SERVICE_URL");
-    }
-    
-    /**
-     * Retrieves the environment variable value for the portal url
-     */
-    String getPortalUrl() {
-        return System.getenv("PORTAL_URL");
     }
 }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/sling/PantheonRepositoryInitializerTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/sling/PantheonRepositoryInitializerTest.java
@@ -33,14 +33,12 @@ class PantheonRepositoryInitializerTest {
         // partial mock
         pri = spy(pri);
         when(pri.getSyncServiceUrl()).thenReturn("http://localhost:8080");
-        when(pri.getPortalUrl()).thenReturn("https://example.com");
 
         // When
         pri.processRepository(mock(SlingRepository.class));
 
         // Then
         verify(mvm).put(eq("pant:syncServiceUrl"), eq("http://localhost:8080"));
-        verify(mvm).put(eq("pant:portalUrl"), eq("https://example.com"));
     }
 
     @Test


### PR DESCRIPTION
ACL issues were causing QA to see partial URLs when calling APIs unauthenticated, this fixes it to read the value directly from the environment variable which is not ACL'ed.