### PR TITLE
CCS-3812: Module details page needs to be refreshed for the "View on portal" link to show-up

### DIFF
--- a/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/assemblyDisplay.tsx
@@ -272,6 +272,9 @@ class AssemblyDisplay extends Component<any, IAssemblyDisplayState> {
 
     private onPublishEvent = () => {
         this.getVersionUUID(this.props.location.pathname)
+        setTimeout(()=> {
+            this.getPortalUrl(this.props.location.pathname.substring(PathPrefixes.MODULE_PATH_PREFIX.length), this.state.variant)
+        }, 500)
     }
 
     private getVersionUUID = (path) => {

--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -302,6 +302,10 @@ class ModuleDisplay extends Component<any, IModuleDisplayState> {
 
     private onPublishEvent = () => {
         this.getVersionUUID(this.props.location.pathname)
+
+        setTimeout(()=> {
+            this.getPortalUrl(this.props.location.pathname.substring(PathPrefixes.MODULE_PATH_PREFIX.length), this.state.variant)
+        }, 500)
     }
 
     private getVersionUUID = (path) => {


### PR DESCRIPTION
This PR
- Calls the url provider endpoint from publish event handler in modules component.
- Adds a wait of 1 sec to the above call so that JCR changes are propagated. This is needed because even though publish endpoint sends 200, it takes nearly a second for changes to propagate in JCR structure.
