### PR TITLE
CCS-3812: Module details page needs to be refreshed for the "View on portal" link to show-up. 

### DIFF
--- a/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/moduleDisplay.tsx
@@ -302,10 +302,10 @@ class ModuleDisplay extends Component<any, IModuleDisplayState> {
 
     private onPublishEvent = () => {
         this.getVersionUUID(this.props.location.pathname)
-
-        setTimeout(()=> {
+        // this is a dirty fix since useEffect hook cannot be used with class based components
+        while (this.state.portalUrl===""){
             this.getPortalUrl(this.props.location.pathname.substring(PathPrefixes.MODULE_PATH_PREFIX.length), this.state.variant)
-        }, 500)
+        }
     }
 
     private getVersionUUID = (path) => {


### PR DESCRIPTION
This PR implements a non-elegent fix since useEffect hook cannot be used with class based components.