### PR TITLE
CCS-3839: Fixing preview issues loading JS, CSS and styling page

### DIFF
--- a/pantheon-bundle/frontend/src/web-assets/dev-preview/ascii-doc-styleguide.html
+++ b/pantheon-bundle/frontend/src/web-assets/dev-preview/ascii-doc-styleguide.html
@@ -28,7 +28,7 @@
   });
 </script>
 </head>
-<body class="article pantheon-render">
+<body class="article pantheon-render rhdocs">
 <cp-documentation>
 <header class="rhdocs__header" id="rhdocs-header">
 <div class="rhdocs__header__primary-wrapper">
@@ -2306,7 +2306,7 @@ Also, don&#8217;t forget to join the <a href="http://discuss.asciidoctor.org">As
 <footer class="rhdocs-footer" id="rhdocs-footer">
 <div class="rhdocs-footer-text" id="rhdocs-footer-text">
 Version 1.0.3<br>
-Last updated 2020-09-30 10:17:24 EDT
+Last updated 2020-10-20 17:02:24 EDT
 </div>
 </footer>
 </cp-documentation>

--- a/pantheon-bundle/frontend/src/web-assets/dev-preview/assembly_access-control-list.html
+++ b/pantheon-bundle/frontend/src/web-assets/dev-preview/assembly_access-control-list.html
@@ -25,7 +25,7 @@
   });
 </script>
 </head>
-<body class="article pantheon-render" id="access-control-list_{context}">
+<body class="article pantheon-render rhdocs" id="access-control-list_{context}">
 <cp-documentation>
 <header class="rhdocs__header" id="rhdocs-header">
 <div class="rhdocs__header__primary-wrapper">
@@ -155,7 +155,7 @@ Guide
 </article>
 <footer class="rhdocs-footer" id="rhdocs-footer">
 <div class="rhdocs-footer-text" id="rhdocs-footer-text">
-Last updated 2020-09-30 10:17:24 EDT
+Last updated 2020-10-20 17:02:24 EDT
 </div>
 </footer>
 </cp-documentation>

--- a/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
+++ b/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
@@ -1,7 +1,7 @@
 !!! 5
 -# Set path to CSS
 - rhDocsCssPath = '/static/rhdocs.css'
-- pantheonCssPath = '/static/pantheon.css'
+- pantheonCssPath = '//access.redhat.com/webassets/avalon/j/public_modules/node_modules/@cpelements/cp-documentation/dist/rhdocs.min.css'
 
 - if (@document.attr :pantheonenv) == 'localwebassets'
   - rhDocsCssPath = '/dev-preview/rhdocs.css'
@@ -51,7 +51,7 @@
         };
       %script(src="https://access.redhat.com/webassets/avalon/j/lib/require.js")
       :javascript
-        chrometwo_require(["wc"], wc => wc.include("@cpelements/cp-documentation/dist/cp-documentation.umd.min"));
+        chrometwo_require(["//access.redhat.com/webassets/avalon/j/public_modules/node_modules/@cpelements/cp-documentation/dist/cp-documentation.umd.js"]);
 
     :javascript
       window.addEventListener('load', function() {
@@ -62,7 +62,7 @@
         }
       });
 
-  %body{:id => @id, :class=>[doctype, 'pantheon-render', ((attr? :toc) && (attr? 'toc-placement', 'auto') ? "has-toc toc-#{attr 'toc-position', 'left'}" : nil)]}
+  %body{:id => @id, :class=>[doctype, 'pantheon-render', 'rhdocs', ((attr? :toc) && (attr? 'toc-placement', 'auto') ? "has-toc toc-#{attr 'toc-position', 'left'}" : nil)]}
     -# Begin main document
 
     -# %cp-documentation#rhdocs.rhdocs


### PR DESCRIPTION
JS for loading cp-documentation stopped working for some reason
CSS was moved to the web component folder and link needed to be changed here
rhdocs is necessary on a wrapper for no-JS version to be styled correctly