### PR TITLE
Bump features to 0.1.2

### DIFF
--- a/pantheon-karaf-feature/src/main/feature/feature.xml
+++ b/pantheon-karaf-feature/src/main/feature/feature.xml
@@ -19,7 +19,7 @@
 -->
 <features name="pantheon-features" xmlns="http://karaf.apache.org/xmlns/features/v1.5.0">
     <!-- Using 0.1.0 version so that 0.1.1 is searched for in any circumstance -->
-    <repository>mvn:org.apache.sling/org.apache.sling.karaf-features/0.1.0-SNAPSHOT/xml/features</repository>
+    <repository>mvn:org.apache.sling/org.apache.sling.karaf-features/0.1.2-SNAPSHOT/xml/features</repository>
     <!-- Pantheon -->
     <feature name="pantheon-bundle" version="${project.version}">
         <feature>sling-models</feature>

--- a/sling-org-apache-sling-karaf-features/pom.xml
+++ b/sling-org-apache-sling-karaf-features/pom.xml
@@ -29,7 +29,7 @@
   </parent>
 
   <artifactId>org.apache.sling.karaf-features</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
   <packaging>feature</packaging>
 
   <name>Apache Sling - Karaf Features</name>


### PR DESCRIPTION
Bump snapshot version for karaf features. This was meant to go along with the configs version but was missed. 