### PR TITLE
Ccs 3842 assembly warning alert

### DIFF
--- a/pantheon-bundle/frontend/src/app/versions.test.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.test.tsx
@@ -3,7 +3,7 @@ import { Versions, IProps } from "@app/versions"
 import "@app/fetchMock"
 
 import { mount, shallow } from "enzyme"
-import { 
+import {
     Button, Form, FormGroup, FormSelect, FormSelectOption, InputGroup,
     InputGroupText, Modal, Title, Alert, AlertActionCloseButton, Grid
 } from "@patternfly/react-core"
@@ -170,9 +170,9 @@ describe("Versions tests", () => {
     });
 
     it("test hideUppublishAlertForModule function", () => {
-    const wrapper = renderer.create(<Versions {...props} />)
-    const inst = wrapper.getInstance()
-    expect(inst.hideUppublishAlertForModule()).toMatchSnapshot()
+        const wrapper = renderer.create(<Versions {...props} />)
+        const inst = wrapper.getInstance()
+        expect(inst.hideUppublishAlertForModule()).toMatchSnapshot()
     })
 
     it("has a props", () => {
@@ -256,5 +256,12 @@ describe("Versions tests", () => {
         inst.capitalize()
         sinon.assert.called(spy)
     })
-    
+
+    it("test getAlertTitle function", () => {
+        const wrapper = renderer.create(<Versions {...props} />)
+        const inst = wrapper.getInstance()
+        const spy = sinon.spy(inst, "getAlertTitle")
+        inst.getAlertTitle()
+        sinon.assert.called(spy)
+    })
 })

--- a/pantheon-bundle/frontend/src/app/versions.test.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.test.tsx
@@ -248,5 +248,13 @@ describe("Versions tests", () => {
         inst.getDocumentsIncluded()
         sinon.assert.called(spy)
     })
+
+    it("test capitalize function", () => {
+        const wrapper = renderer.create(<Versions {...props} />)
+        const inst = wrapper.getInstance()
+        const spy = sinon.spy(inst, "capitalize")
+        inst.capitalize()
+        sinon.assert.called(spy)
+    })
     
 })

--- a/pantheon-bundle/frontend/src/app/versions.test.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.test.tsx
@@ -257,11 +257,11 @@ describe("Versions tests", () => {
         sinon.assert.called(spy)
     })
 
-    it("test getAlertTitle function", () => {
+    it("test setAlertTitle function", () => {
         const wrapper = renderer.create(<Versions {...props} />)
         const inst = wrapper.getInstance()
-        const spy = sinon.spy(inst, "getAlertTitle")
-        inst.getAlertTitle()
+        const spy = sinon.spy(inst, "setAlertTitle")
+        inst.setAlertTitle()
         sinon.assert.called(spy)
     })
 })

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -35,6 +35,7 @@ export interface IProps {
 }
 
 interface IState {
+    alertTitle: any
     allProducts: any
     allProductVersions: any
     canChangePublishState: boolean
@@ -69,6 +70,7 @@ class Versions extends Component<IProps, IState> {
     constructor(props) {
         super(props)
         this.state = {
+            alertTitle: "",
             allProducts: [],
             // tslint:disable-next-line: object-literal-sort-keys
             allProductVersions: [],
@@ -136,7 +138,7 @@ class Versions extends Component<IProps, IState> {
                 {this.state.publishAlertVisible && <div className="notification-container pant-notification-container-md">
                     <Alert
                         variant="warning"
-                        title="Publishing Document"
+                        title={this.state.alertTitle}
                         actionClose={<AlertActionCloseButton onClose={this.hidePublishAlert} />}
                     >
                         {this.capitalize(this.props.contentType)} failed to publish. Check the following:
@@ -518,6 +520,7 @@ class Versions extends Component<IProps, IState> {
                     } else {
                         console.log(buttonText + " failed " + response.status)
                         this.setState({ publishAlertVisible: true })
+                        this.getAlertTitle()
                     }
                     this.fetchVersions()
                 });
@@ -750,6 +753,11 @@ class Versions extends Component<IProps, IState> {
             return
         }
         return str.charAt(0).toUpperCase() + str.slice(1)
+    }
+
+    private getAlertTitle = () => {
+        const alertTitle = "Publishing " + this.props.contentType
+        this.setState({ alertTitle })
     }
 }
 

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -35,7 +35,7 @@ export interface IProps {
 }
 
 interface IState {
-    alertTitle: any
+    alertTitle: string
     allProducts: any
     allProductVersions: any
     canChangePublishState: boolean
@@ -520,7 +520,7 @@ class Versions extends Component<IProps, IState> {
                     } else {
                         console.log(buttonText + " failed " + response.status)
                         this.setState({ publishAlertVisible: true })
-                        this.getAlertTitle()
+                        this.setAlertTitle()
                     }
                     this.fetchVersions()
                 });
@@ -755,7 +755,7 @@ class Versions extends Component<IProps, IState> {
         return str.charAt(0).toUpperCase() + str.slice(1)
     }
 
-    private getAlertTitle = () => {
+    private setAlertTitle = () => {
         const alertTitle = "Publishing " + this.props.contentType
         this.setState({ alertTitle })
     }

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -136,13 +136,13 @@ class Versions extends Component<IProps, IState> {
                 {this.state.publishAlertVisible && <div className="notification-container pant-notification-container-md">
                     <Alert
                         variant="warning"
-                        title="Module Versions"
+                        title="Publishing Document"
                         actionClose={<AlertActionCloseButton onClose={this.hidePublishAlert} />}
                     >
-                        Module failed to publish. Check the following:
+                        {this.capitalize(this.props.contentType)} failed to publish. Check the following:
                         <ul>
                             <li>Are you logged in as a publisher?</li>
-                            <li>Does the module have all required metadata?</li>
+                            <li>Does the {this.props.contentType} have all required metadata?</li>
                         </ul>
                     </Alert>
                 </div>
@@ -743,6 +743,13 @@ class Versions extends Component<IProps, IState> {
                     }
                 })
         }
+    }
+
+    private capitalize = (str) => {
+        if (str === undefined || str.trim().length === 0) {
+            return
+        }
+        return str.charAt(0).toUpperCase() + str.slice(1)
     }
 }
 


### PR DESCRIPTION
This PR fixes the wording of Publish Warning for assembly. currently when an assembly failed to publish, the warning message states:
  
  Module versions
  Module failed to publish. Check the following:
     * Are you logged in as a publisher?
     * Does the module have all required metadata?

The new message looks like this:
  Publishing Document
  Assembly failed to publish. Check the following:
     * Are you logged in as a publisher?
     * Does the assembly have all required metadata?
