### PR TITLE
CCS-3849: Empty value in included_in_guides

### DIFF
--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/util/ServletHelper.java
@@ -142,7 +142,7 @@ public class ServletHelper {
         AssemblyVariant assemblyVariant = resource.adaptTo(AssemblyVariant.class);
         HashMap<String,String> assemblyVariantDetails = new HashMap<>();
         // if draft version cannot be added, however only draft exists, then just return
-        if(!canHaveDraft&&assemblyVariant.hasDraft()){
+        if(!canHaveDraft&&assemblyVariant.hasDraft()&&!assemblyVariant.released().isPresent()){
             return;
         }
         Optional<AssemblyMetadata> metadata = traverseFrom(assemblyVariant)

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/servlet/util/ServletHelperTest.java
@@ -110,6 +110,48 @@ public class ServletHelperTest {
         assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
         assertTrue(includeAssemblies.get(0).containsKey("path"));
     }
+    @Test
+    void setAssemblyDetailsTestWithDraftAndReleaseAndCantAddDraft() throws RepositoryException {
+        slingContext.build()
+                .resource("/content/repositories/rhel-8-docs",
+                        "jcr:primaryType", "pant:workspace")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes",
+                        "jcr:primaryType", "pant:assembly")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT",
+                        "jcr:primaryType", "pant:assemblyVariant")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/metadata",
+                        "jcr:title", "A title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/released/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9012")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft",
+                        "jcr:primaryType", "pant:assemblyVersion")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/metadata",
+                        "jcr:title", "A new title",
+                        "jcr:description", "A description")
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/cached_html/jcr:content",
+                        "jcr:data", testHTML)
+                .resource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT/draft/content/0",
+                        "jcr:moduleVariantUuid", "1234-5678-9022")
+                .commit();
+
+        registerMockAdapter(AssemblyVariant.class, slingContext);
+
+        AssemblyVariantJsonServlet servlet = new AssemblyVariantJsonServlet();
+        slingContext.request().setResource( slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT") );
+
+
+        List<HashMap<String, String>> includeAssemblies =new ArrayList<>();
+        ServletHelper.setAssemblyData(slingContext.resourceResolver().getResource("/content/repositories/rhel-8-docs/entities/assemblies/changes/en_US/variants/DEFAULT")
+                , includeAssemblies,true, false);
+        assertFalse(includeAssemblies.isEmpty(),"assembly details should not be empty ");
+        assertTrue(includeAssemblies.get(0).containsKey("path"));
+        assertEquals("A title", includeAssemblies.get(0).get("title"));
+    }
 
     @Test
     void setAssemblyDetailsTestWithPathAndDraft() throws RepositoryException {


### PR DESCRIPTION
This PR fixes the issue where included_in_guides has empty value when both draft and released versions are present.