### PR TITLE
Minor change to the "Configuring your repository" assembly.

### DIFF
--- a/pantheon-bundle/src/main/resources/SLING-INF/content/docs/assemblies/assembly-configuring-repository.adoc
+++ b/pantheon-bundle/src/main/resources/SLING-INF/content/docs/assemblies/assembly-configuring-repository.adoc
@@ -1,6 +1,6 @@
-ifdef::context[:parent-context: {context}]
-
 include::../attributes.adoc[]
+
+ifdef::context[:parent-context: {context}]
 
 [id="configuring_repository_{context}"]
 = Configuring your repository


### PR DESCRIPTION
Interestingly, this one-line change resolves an error running the AsciiDoctor command. Because this assembly does not render correctly in Pantheon V2 today, and this is the only difference I can see between this and other assemblies, my guess is that this will resolve that issue as well.