### PR TITLE
PDF generation

### DIFF
--- a/pantheon-bundle/pom.xml
+++ b/pantheon-bundle/pom.xml
@@ -79,6 +79,8 @@
                             com.redhat.pantheon.use
                         </Sling-Model-Packages>
                         <Import-Package>
+                            javax.security.auth.x500,
+                            javax.security.cert,
                             !jnr.a64asm,!jnr.x86asm,!org.apache.bsf,!org.apache.bsf.util,
                             !org.apache.tools.ant,!org.joda.convert,!org.objectweb.asm,!sun.misc,
                             !javax.ejb,
@@ -275,6 +277,11 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
             <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj-pdf</artifactId>
+            <version>1.5.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorService.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/AsciidoctorService.java
@@ -472,6 +472,13 @@ public class AsciidoctorService {
                     .noFooter(true)
                     // link the css instead of embedding it
                     .linkCss(true)
+                    // only needed for PDF
+                    .allowUriRead(true)
+                    // only needed for PDF
+                    // TODO If a url prefix is given here, asciidoctor pdf is able to resolve images
+                    //  from this base url. So, giving it a hardcoded pantheon base url would allow this
+                    //  pantheon instance to serve images to itself while generating PDFs
+                    //.imagesDir("")
                     // stylesheet reference
                     .styleSheetName("/static/rhdocs.css");
 
@@ -516,9 +523,9 @@ public class AsciidoctorService {
                     .safe(SafeMode.UNSAFE) // This probably needs to change
                     .inPlace(false)
                     // Generate the html header and footer
-                    .headerFooter(true);
+                    .headerFooter(true)
                     // use the provided attributes
-//                    .attributes(atts);
+                    .attributes(atts);
             globalConfig.getTemplateDirectory().ifPresent(ob::templateDir);
 
             long start = System.currentTimeMillis();

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVersion.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/model/document/DocumentVersion.java
@@ -25,6 +25,9 @@ public interface DocumentVersion extends WorkspaceChild {
     @Named("cached_html")
     Child<FileResource> cachedHtml();
 
+    @Named("cached_pdf")
+    Child<FileResource> cachedPdf();
+
     Child<? extends DocumentMetadata> metadata();
 
     @Named("ack_status")

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
@@ -1,0 +1,57 @@
+package com.redhat.pantheon.servlet.module;
+
+import com.google.common.collect.Maps;
+import com.google.common.io.ByteStreams;
+import com.redhat.pantheon.asciidoctor.AsciidoctorService;
+import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.model.document.Document;
+import com.redhat.pantheon.model.document.DocumentVariant;
+import com.redhat.pantheon.model.module.Module;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Component(
+        service = Servlet.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=Servlet which transforms asciidoc content into pdf",
+                Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
+        })
+@SlingServletResourceTypes(
+        resourceTypes = {"pantheon/module"},
+        methods = "GET",
+        extensions = "pdf")
+public class PdfRenderer extends SlingSafeMethodsServlet {
+
+    @Reference
+    AsciidoctorService asciidoctorService;
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
+
+        Module module = request.getResource().adaptTo(Module.class);
+
+        File resultingFile = asciidoctorService.buildDocumentPdf(module, GlobalConfig.DEFAULT_MODULE_LOCALE,
+                DocumentVariant.DEFAULT_VARIANT_NAME, true, Maps.newHashMap(), true);
+
+        response.setStatus(200);
+        response.setContentType("application/pdf");
+        try (InputStream inputStream = new FileInputStream(resultingFile)) {
+             ByteStreams.copy(inputStream, response.getOutputStream());
+        }
+
+        // TODO at this point the temp file still exists. Figure out what to do with it.
+    }
+}

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.model.document.Document;
 import com.redhat.pantheon.model.document.DocumentVariant;
 import com.redhat.pantheon.model.module.Module;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -16,10 +17,12 @@ import org.osgi.service.component.annotations.Reference;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Rendering servlet for PDFs
+ */
 @Component(
         service = Servlet.class,
         property = {
@@ -27,7 +30,7 @@ import java.io.InputStream;
                 Constants.SERVICE_VENDOR + "=Red Hat Content Tooling team"
         })
 @SlingServletResourceTypes(
-        resourceTypes = {"pantheon/module"},
+        resourceTypes = {"pantheon/module", "pantheon/assembly"},
         methods = "GET",
         extensions = "pdf")
 public class PdfRenderer extends SlingSafeMethodsServlet {
@@ -38,16 +41,14 @@ public class PdfRenderer extends SlingSafeMethodsServlet {
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
 
-        Module module = request.getResource().adaptTo(Module.class);
+        Document document = request.getResource().adaptTo(Document.class);
 
         InputStream pdfFile =
-                asciidoctorService.buildDocumentPdf(module, GlobalConfig.DEFAULT_MODULE_LOCALE,
+                asciidoctorService.buildDocumentPdf(document, GlobalConfig.DEFAULT_MODULE_LOCALE,
                     DocumentVariant.DEFAULT_VARIANT_NAME, true, Maps.newHashMap(), true);
 
         response.setStatus(200);
         response.setContentType("application/pdf");
         ByteStreams.copy(pdfFile, response.getOutputStream());
-
-        // TODO at this point the temp file still exists. Figure out what to do with it.
     }
 }

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/servlet/module/PdfRenderer.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import com.redhat.pantheon.asciidoctor.AsciidoctorService;
 import com.redhat.pantheon.conf.GlobalConfig;
-import com.redhat.pantheon.model.document.Document;
 import com.redhat.pantheon.model.document.DocumentVariant;
 import com.redhat.pantheon.model.module.Module;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -17,8 +16,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,14 +40,13 @@ public class PdfRenderer extends SlingSafeMethodsServlet {
 
         Module module = request.getResource().adaptTo(Module.class);
 
-        File resultingFile = asciidoctorService.buildDocumentPdf(module, GlobalConfig.DEFAULT_MODULE_LOCALE,
-                DocumentVariant.DEFAULT_VARIANT_NAME, true, Maps.newHashMap(), true);
+        InputStream pdfFile =
+                asciidoctorService.buildDocumentPdf(module, GlobalConfig.DEFAULT_MODULE_LOCALE,
+                    DocumentVariant.DEFAULT_VARIANT_NAME, true, Maps.newHashMap(), true);
 
         response.setStatus(200);
         response.setContentType("application/pdf");
-        try (InputStream inputStream = new FileInputStream(resultingFile)) {
-             ByteStreams.copy(inputStream, response.getOutputStream());
-        }
+        ByteStreams.copy(pdfFile, response.getOutputStream());
 
         // TODO at this point the temp file still exists. Figure out what to do with it.
     }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
@@ -1,0 +1,34 @@
+package com.redhat.pantheon.asciidoctor;
+
+import com.redhat.pantheon.conf.GlobalConfig;
+import com.redhat.pantheon.sling.ServiceResourceResolverProvider;
+import org.asciidoctor.Asciidoctor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class})
+class AsciidoctorServiceTest {
+
+    @Test
+    void generatePdf() throws IOException {
+        AsciidoctorPool pool = mock(AsciidoctorPool.class);
+        when(pool.borrowObject()).thenReturn(Asciidoctor.Factory.create());
+
+        AsciidoctorService asciidoctorService = new AsciidoctorService(
+                mock(GlobalConfig.class),
+                pool,
+                mock(ServiceResourceResolverProvider.class)
+        );
+
+//        System.out.println(
+//                asciidoctorService.generatePdf(null).getAbsolutePath());
+    }
+}

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/AsciidoctorServiceTest.java
@@ -19,16 +19,6 @@ class AsciidoctorServiceTest {
 
     @Test
     void generatePdf() throws IOException {
-        AsciidoctorPool pool = mock(AsciidoctorPool.class);
-        when(pool.borrowObject()).thenReturn(Asciidoctor.Factory.create());
-
-        AsciidoctorService asciidoctorService = new AsciidoctorService(
-                mock(GlobalConfig.class),
-                pool,
-                mock(ServiceResourceResolverProvider.class)
-        );
-
-//        System.out.println(
-//                asciidoctorService.generatePdf(null).getAbsolutePath());
+        // TODO add a test here
     }
 }


### PR DESCRIPTION
This is a preview for PDF generation of pantheon content using the asciidoctor-pdf library.

To access a basic PDF render of any document just access its full path in the document using the pdf extension. For example:

`GET http://<server>/path/to/document.adoc.pdf?draft=true` (note the draft parameter is being used)

**Known issues and other comments**
- Images are not being inserted into the documents
- Stylesheets are out-of-the-box
- The pdf file is being generated on every request