### PR TITLE
CCS-4163: Use the new uploader in the existing git2pantheo

### DIFF
--- a/pantheon-bundle/frontend/src/app/gitImport.tsx
+++ b/pantheon-bundle/frontend/src/app/gitImport.tsx
@@ -109,11 +109,12 @@ class GitImport extends Component {
                     branch: this.state.branch,
                     repo: this.state.repository
                   };
-                  fetch(this.state.git2pantheonURL + "/clone", {
+                  fetch(this.state.git2pantheonURL + "/api/clone", {
                     body: JSON.stringify(payload),
                     method: "POST"
                   }).then(response => {
-                    if (response.status === 201 || response.status === 200) {
+                    // check 202 as well if 201 is being checked
+                    if (response.status === 201 || response.status === 200 || response.status === 202) {
                       console.log(" Works " + response.status)
                       this.setState({ isFormSubmitted: true, isSucess: true, msgType: "success", submitMsg: "The git import has been submitted it might take up to 1 minute to see it in the module library." })
                     } else if (response.status === 500) {

--- a/tools/git2pantheon/git_uploader.go
+++ b/tools/git2pantheon/git_uploader.go
@@ -33,7 +33,7 @@ func gitClone(repository string, branch string, directory string) {
 
 func getUploader() {
 	if _, err := os.Stat("./pantheon.py"); os.IsNotExist(err) {
-		const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"
+		const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon-uploader/master/pantheon_uploader/pantheon.py"
 		args := []string{"-o", "./pantheon.py", uploader_url}
 		cmd := exec.Command("curl", args...)
 		out, err := cmd.Output()

--- a/tools/git2pantheon/main.go
+++ b/tools/git2pantheon/main.go
@@ -97,8 +97,8 @@ func init() {
 func main() {
 	flag.Parse()
 	mux := http.NewServeMux()
-	mux.HandleFunc("/clone", cloneBranch)
-	mux.HandleFunc("/info", getInfo)
+	mux.HandleFunc("/api/clone", cloneBranch)
+	mux.HandleFunc("/api/info", getInfo)
 
 	getUploader()
 


### PR DESCRIPTION
This PR:
- Tweaks current go app to use the new [uploader|https://github.com/redhataccess/pantheon-uploader] file
   - Change _const uploader_url =_ _"https://raw.githubusercontent.com/redhataccess/pantheon/master/uploader/pantheon.py"_ to _const uploader_url = "https://raw.githubusercontent.com/redhataccess/pantheon-uploader/master/pantheon_uploader/pantheon.py_"
- Consolidate existing Go app's APIs under /api 