### PR TITLE
FCCEUD-53: Declare the :LinkToSearchPage: attribute

### DIFF
--- a/pantheon-bundle/src/main/resources/SLING-INF/content/docs/attributes.adoc
+++ b/pantheon-bundle/src/main/resources/SLING-INF/content/docs/attributes.adoc
@@ -15,6 +15,7 @@
 // Publishing
 :PublishingPortal: Customer Portal
 :PublishingPortalSearch: Customer Portal Search
+:LinkToSearchPage: https://pantheon.corp.redhat.com/pantheon/#/search
 
 :imagesdir: images
 :ContentTerm: content


### PR DESCRIPTION
* Declared the attribute LinkToSearchPage with the present search page
url