### PR TITLE
WIP: FCCEUD-58 Update Contributing to Pantheon

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Whenever you work on a new issue, you must create a new working branch based on 
        ```
        $ git pull upstream master
        ```
-1. Create a working branch based on the issue in JIRA:
+1. Create a working branch based on the issue in JIRA. For example:
        ```
-       $ git checkout -b FCCEUD<ID#>
+       $ git checkout -b FCCEUD-<ID#>
        ```       
 
 ### Creating a pull request and completing review

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ and built on top of Apache sling.
   [Signing up for a new GitHub account](https://help.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account)
 * You must have registered SSH keys in your GitHub account.
 [Adding a new SSH key to your GitHub account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
-* You must be a member of the `pantheon-doc-authors` team in the `redhataccess` group in GitHub.
+* You must be a member of the `pantheon-developers` or `pantheon-doc-authors` team in the `redhataccess` group in GitHub.
 * You must be logged in to your account on GitHub.
 
 ### Forking the repository
@@ -42,44 +42,61 @@ Fork the repository so that you can create and work with branches independently 
 After you have forked the repository, you must clone it to your local machine and add the original `redhataccess/pantheon` repository as an upstream remote.
 
 1. From a terminal, clone the repository:
+       ```
        $ git clone git@github.com:<user-space>/pantheon.git
+       ```
 1. Set up `redhataccess/pantheon` as the upstream:
+       ```
        $ cd pantheon
        $ git remote add upstream git@github.com:redhataccess/pantheon.git
+       ```
 
 ### Creating a working branch
 
 Whenever you work on a new issue, you must create a new working branch based on the latest version of the upstream master branch.
 
 1. Ensure you are on master
+       ```
        $ git checkout master
+       ```
 1. Ensure your fork is up to date
+       ```
        $ git pull upstream master
+       ```
 1. Create a working branch based on the issue in JIRA:
+       ```
        $ git checkout -b FCCEUD<ID#>
+       ```       
 
 ### Creating a pull request and completing review
 
 When your work is ready to be reviewed and merged, create a pull request.
 
 1. Push your working branch to your fork:
+       ```
        $ git push -u origin <branch_name>
+       ```
 1. From the repository page in GitHub, click **New pull request**.
 1. Select your working branch from the compare list.
-1. Add `WIP` to the title of the pull request.
+1. Add `WIP:` to the title of the pull request. This automatically converts the pull request to a draft pull request.
+1. Click **Create new pull request**.
 1. Add the **awaiting tech review** label to the pull request.
 1. In the pull request comment field, enter `@redhataccess/pantheon-developers Please review for technical completeness and accuracy`.
-1. Click **Create new pull request**.
 
-For code pull requests, one or more developers review the pull request. For documentation pull requests, the developers review the pull request for technical accuracy and documentation team members review the pull request for clarity, consistency, and compliance with necessary standards.
 
 ### The review process
 
 Both the technical review and peer review processes take place in pull requests in GitHub.
 
+#### Documentation review
 After creating and labeling a pull request as outlined above, the developers review the pull request and add comments regarding technical accuracy. Writers receive a notification that comments have been added via email, and when all comments have been addressed, the developers change the label from **awaiting tech review** to **tech review passed**.
 
-When technical review is complete, writers click the **Reviewers** gear icon and select the name of a team member to request peer review. Writers receive a notification that comments have been added via email, and when all comments have been addressed, the reviewer clicks **Review changes > Approve** from the **Files changed** tab of the pull request to approve the changes and the pull request.
+When technical review is complete, writers click the **Reviewers** gear icon and select the name of a team member to request peer review. The peer writer reviews the pull request for clarity, consistency, and compliance with necessary standards.
+Writers receive a notification that comments have been added via email, and when all comments have been addressed, the reviewer clicks **Review changes > Approve** from the **Files changed** tab of the pull request to approve the changes and the pull request.
+
+#### Code review
+
+For code pull requests, one or more developers review the pull request.
 
 ### Merging a pull request
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ When your work is ready to be reviewed and merged, create a pull request.
 Both the technical review and peer review processes take place in pull requests in GitHub.
 
 #### Documentation review
-After creating and labeling a pull request as outlined above, the developers review the pull request and add comments regarding technical accuracy. Writers receive a notification that comments have been added via email, and when all comments have been addressed, the developers change the label from **awaiting tech review** to **tech review passed**.
+After creating and labeling a pull request as outlined above, the developers review the pull request and add comments regarding technical accuracy. Writers receive a notification that comments have been added via email, and when all comments have been addressed, the developers change the label from **awaiting tech review** to **tech review complete**.
 
 When technical review is complete, writers click the **Reviewers** gear icon and select the name of a team member to request peer review. The peer writer reviews the pull request for clarity, consistency, and compliance with necessary standards.
 Writers receive a notification that comments have been added via email, and when all comments have been addressed, the reviewer clicks **Review changes > Approve** from the **Files changed** tab of the pull request to approve the changes and the pull request.
@@ -109,7 +109,7 @@ When you have addressed all technical review and peer review comments, notify th
 1. Remove `WIP` from the title of the pull request.
 1. Click **Request Review** and enter `@redhataccess/pantheon-developers`.
 
-The developers check that the **Tech review passed** label has been added to the pull request and peer pull request approval provided, then accept it.
+The developers check that the **Tech review complete** label has been added to the pull request and peer pull request approval provided, then accept it.
 
 ## Installing Pantheon
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ and built on top of Apache sling.
 
 ## Contributing to Pantheon
 
+### Filing a bug for Pantheon 2 end-user documentation
+
+If you have any suggestions to improve or extend the end-user documentation, create a new issue and tag @pantheon-doc-authors.
+
 ### Prerequisites
 
 * You must have an account on GitHub.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When your work is ready to be reviewed and merged, create a pull request.
 1. Add `WIP:` to the title of the pull request. This automatically converts the pull request to a draft pull request.
 1. Click **Create new pull request**.
 1. Add the **awaiting tech review** label to the pull request.
-1. In the pull request comment field, enter `@redhataccess/pantheon-developers Please review for technical completeness and accuracy`.
+1. In the pull request comment field, enter `@redhataccess/eud-tech-review Please review for technical completeness and accuracy`.
 
 
 ### The review process
@@ -96,7 +96,7 @@ Writers receive a notification that comments have been added via email, and when
 
 #### Code review
 
-For code pull requests, one or more developers review the pull request.
+For code pull requests, one or more developers review the pull request. A contributor submits a PR and uses Github's **Reviewers** gear icon to tag `@redhataccess/pantheon-developers`. A developer comments on the code, and discusses it with the submitter, before ultimately deciding to accept or reject the PR.
 
 ### Merging a pull request
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/FCCEUD-58
Contributing to Pantheon (https://github.com/redhataccess/pantheon) targets all contributors, but it currently includes some guidance that is clearly targeting FCCEUD contributors without including similar content for other contributors.

E.g. Prerequisites include the following line: You must be a member of the pantheon-doc-authors team in the redhataccess group in GitHub.