### PR TITLE
CCS-4142-SSO-integration-fixes4

### DIFF
--- a/pantheon-karaf-feature/src/main/feature/feature.xml
+++ b/pantheon-karaf-feature/src/main/feature/feature.xml
@@ -70,7 +70,7 @@
                 end\n\
                 \n\
                 set ACL for pantheon-administrators\n\
-                allow jcr:all on / restriction(rep:glob,*)\n\
+                allow jcr:all on / \n\
                 end\n\
                 \n\
                 set ACL for pantheon-authors\n\


### PR DESCRIPTION
This PR fixes the ACL for pantheon-administrators. Without the fix, users with pantheon-administrators role can only see /content in the jcr tree when accessing /bin/browser.html