### PR TITLE
CCS-4270-bulk_edit_metadata_bugfixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`BulkOperationMetadata tests should render BulkOperationMetadata compone
       Array [
         <Button
           form="bulk_edit_metadata"
+          isAriaDisabled={false}
           onClick={[Function]}
           variant="primary"
         >

--- a/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
@@ -253,6 +253,7 @@ exports[`Search tests should render default Search component 1`] = `
             </Select>
           </ToolbarFilter>
         </ForwardRef>
+        .
       </ToolbarToggleGroup>
       <ForwardRef
         variant="icon-button-group"

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -80,7 +80,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                     aria-label="Edit metadata"
                     onClose={this.handleModalClose}
                     actions={[
-                        <Button form="bulk_edit_metadata" key="confirm" variant="primary" onClick={this.saveMetadata}>
+                        <Button form="bulk_edit_metadata" isAriaDisabled={this.props.documentsSelected.length === 0 ? true : false} key="confirm" variant="primary" onClick={this.saveMetadata}>
                             Save
                 </Button>,
                         <Button data-testid="metadata-modal-cancel-button" key="cancel" variant="secondary" onClick={this.handleModalToggle}>
@@ -267,7 +267,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
     private onChangeUsecase = (usecaseValue, event) => {
         if (event != undefined) {
             this.setState({ usecaseValue: event.target.value })
-            // console.log("[onChangeUsecase] event.target.value=>", event.target.value)
+
             if (event.target.value !== "" && event.target.value.trim() !== "Select Use Case") {
                 this.setState({ useCaseValidated: "success" })
             } else {
@@ -337,7 +337,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
             formData.append("searchKeywords", this.state.keywords === undefined ? "" : this.state.keywords)
 
             this.props.documentsSelected.map((r) => {
-                // console.log("[saveMetadata] documentsSelected href =>", r.cells[1].title.props.href)
                 if (r.cells[1].title.props.href) {
                     let href = r.cells[1].title.props.href
 
@@ -357,7 +356,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                 method: "post"
                             }).then(response => {
                                 if (response.status === 201 || response.status === 200) {
-                                    // console.log("successful edit ", response.status + " for  path: " + backend)
 
                                     let docs = new Array()
                                     docs = this.state.documentsSucceeded
@@ -372,14 +370,13 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                         productVersionValidated: "error",
                                         useCaseValidated: "error",
                                         bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
-                                        // showBulkEditConfirmation: true,
                                     }, () => {
                                         this.handleModalClose()
-                                        
+
                                         this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
                                     })
                                 } else {
-                                    
+
                                     let docs = new Array()
                                     docs = this.state.documentsFailed
                                     docs.push(docPath)
@@ -392,15 +389,14 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                             })
                         } else {
                             // draft does not exist
-                            // console.log("[saveMetadata] no draft version found:", backend)
                             let docs = new Array()
                             docs = this.state.documentsIgnored
                             docs.push(docPath)
                             this.setState({ bulkUpdateWarning: this.state.bulkUpdateWarning + 1, documentsIgnored: docs }, () => {
-                                
+
                                 this.calculateWarningProgress(this.state.bulkUpdateWarning)
                                 if (this.state.bulkUpdateWarning > 0 && this.state.bulkUpdateWarning === this.props.documentsSelected.length) {
-                                    
+
                                     this.setState({ metadataEditError: "No draft versions found on selected items. Unable to save metadata." })
                                 }
                             })

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -55,7 +55,7 @@ export interface ISearchState {
   isModalOpen: boolean
   isEditMetadata: boolean
   editMetadataWarn: boolean
-  isMetadataButtonDisabled: boolean
+  isBulkOperationButtonDisabled: boolean
 }
 class Search extends Component<IAppState, ISearchState> {
   private drawerRef: React.RefObject<HTMLInputElement>;
@@ -99,7 +99,7 @@ class Search extends Component<IAppState, ISearchState> {
       isModalOpen: false,
       isEditMetadata: false,
       editMetadataWarn: false,
-      isMetadataButtonDisabled: true,
+      isBulkOperationButtonDisabled: true,
     };
     this.drawerRef = React.createRef();
 
@@ -299,7 +299,7 @@ class Search extends Component<IAppState, ISearchState> {
         <ToolbarGroup variant="icon-button-group">
         </ToolbarGroup>
         {this.props.userAuthenticated && (this.props.isAuthor || this.props.isPublisher || this.props.isAdmin) && <ToolbarItem>
-          <Button variant="primary" isAriaDisabled={this.state.isMetadataButtonDisabled || this.state.repositoriesSelected.length === 0} onClick={this.handleEditMetadata} data-testid="edit_metadata">Edit metadata</Button>
+          <Button variant="primary" isAriaDisabled={this.state.isBulkOperationButtonDisabled || this.state.repositoriesSelected.length === 0} onClick={this.handleEditMetadata} data-testid="edit_metadata">Edit metadata</Button>
         </ToolbarItem>}
         {this.props.userAuthenticated && (this.props.isPublisher || this.props.isAdmin) && <ToolbarItem>
           <Button variant="primary" isAriaDisabled={true}>Publish</Button>
@@ -545,7 +545,7 @@ class Search extends Component<IAppState, ISearchState> {
       repositoriesSelected
     }, () => {
       if (this.state.repositoriesSelected.length === 0) {
-        this.setState({ documentsSelected: [], isMetadataButtonDisabled: true })
+        this.setState({ documentsSelected: [], isBulkOperationButtonDisabled: true })
       }
 
       if (this.state.repositoriesSelected.length === 1 && this.state.editMetadataWarn === true) {
@@ -584,14 +584,14 @@ class Search extends Component<IAppState, ISearchState> {
       this.setState({
         contentTypeSelected: '',
         documentsSelected: [],
-        isMetadataButtonDisabled: true
+        isBulkOperationButtonDisabled: true
       })
     } else {
       this.setState({ documentsSelected }, () => {
         if (this.state.documentsSelected.length > 0) {
-          this.setState({ isMetadataButtonDisabled: false })
+          this.setState({ isBulkOperationButtonDisabled: false })
         } else {
-          this.setState({ isMetadataButtonDisabled: true })
+          this.setState({ isBulkOperationButtonDisabled: true })
         }
       })
     }
@@ -605,7 +605,7 @@ class Search extends Component<IAppState, ISearchState> {
   private handleEditMetadata = (event) => {
     if (this.state.repositoriesSelected.length > 1) {
       this.setState({ editMetadataWarn: true }, () => {
-        this.setState({ isMetadataButtonDisabled: true })
+        this.setState({ isBulkOperationButtonDisabled: true })
       })
     } else {
       this.setState({
@@ -613,9 +613,9 @@ class Search extends Component<IAppState, ISearchState> {
         editMetadataWarn: false
       }, () => {
         if (this.state.editMetadataWarn === false && this.state.repositoriesSelected.length === 1) {
-          this.setState({ isMetadataButtonDisabled: false })
+          this.setState({ isBulkOperationButtonDisabled: false })
         } else {
-          this.setState({ isMetadataButtonDisabled: true })
+          this.setState({ isBulkOperationButtonDisabled: true })
         }
       })
     }

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -350,7 +350,6 @@ class SearchResults extends Component<IProps, ISearchState> {
     this.setState({
       rows
     });
-    // console.log("[onSelect] bulkSelected rows =>", rows)
     // update props.documentSelected
     let selectedRows;
     selectedRows = this.state.rows.map(oneRow => {
@@ -360,10 +359,9 @@ class SearchResults extends Component<IProps, ISearchState> {
     })
     // filter undefined values
     selectedRows = selectedRows.filter(r => r !== undefined)
-    // console.log("[onSelect] bulkSelected selectedRows =>", selectedRows)
-    if (selectedRows.length > 0) {
-      this.props.onGetdocumentsSelected(selectedRows);
-    }
+
+    this.props.onGetdocumentsSelected(selectedRows);
+
     if (selectedRows.length > 0 || isSelected == true) {
       this.props.onSelectContentType(this.props.contentType);
     }


### PR DESCRIPTION
This PR hide Edit metadata button when no documents are selected. This requires users to select documents before clicking on Edit Metadata button.