### PR TITLE
change list to ordered list to show user item counts

### DIFF
--- a/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType } from '@patternfly/react-core';
 import "@app/app.css";
 
 export interface IBulkPublishProps {
@@ -74,11 +74,11 @@ class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
           <strong>{`${this.props.isBulkUnpublish ? "Unpublished" : "Published"} Succeessfully:`}</strong>
           <br />
           <span id="update-succeeded">
-            <List aria-label="succeeded">
+            <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateSucceeded.length > 0 &&
-                this.props.updateSucceeded.split(",").map((data) => (
+                this.props.updateSucceeded.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -86,11 +86,11 @@ class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
           <br />
           {!this.props.isBulkUnpublish && (<div><strong>Publish Ignored:</strong>
           <span id="update-ignored">
-            <List aria-label="ignored">
+            <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateIgnored.length > 0 &&
-                this.props.updateIgnored.split(",").map((data) => (
+                this.props.updateIgnored.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span></div>)}
@@ -99,11 +99,11 @@ class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
           <strong>{`${this.props.isBulkUnpublish ? "Unpublish" : "Publish"} Failed:`}</strong>
           <br />
           <span id="update-failed">
-            <List aria-label="failed">
+            <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateFailed.length > 0 &&
-                this.props.updateFailed.split(",").map((data) => (
+                this.props.updateFailed.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>

--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationConfirmation.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationConfirmation.test.tsx.snap
@@ -128,14 +128,22 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
     >
       <List
         aria-label="succeeded"
+        component="ol"
+        type="1"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositories/s/a
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="1"
+        >
           /repositories/s/b
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="2"
+        >
           /repositories/s/c
         </ListItem>
       </List>
@@ -151,11 +159,17 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
     >
       <List
         aria-label="ignored"
+        component="ol"
+        type="1"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositorires/i/a
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="1"
+        >
           /repositorires/i/b
         </ListItem>
       </List>
@@ -171,8 +185,12 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
     >
       <List
         aria-label="failed"
+        component="ol"
+        type="1"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositories/f/a
         </ListItem>
       </List>

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 import "@app/app.css";
 
@@ -73,11 +73,11 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <strong>Update Succeeded:</strong>
           <br />
           <span id="update-succeeded">
-            <List aria-label="succeeded">
+            <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateSucceeded.length > 0 &&
-                this.props.updateSucceeded.split(",").map((data) => (
+                this.props.updateSucceeded.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -86,11 +86,11 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <strong>Update Ignored:</strong>
           <br />
           <span id="update-ignored">
-            <List aria-label="ignored">
+            <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateIgnored.length > 0 &&
-                this.props.updateIgnored.split(",").map((data) => (
+                this.props.updateIgnored.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -99,11 +99,11 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <strong>Update Failed:</strong>
           <br />
           <span id="update-failed">
-            <List aria-label="failed">
+            <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
               {this.props.updateFailed.length > 0 &&
-                this.props.updateFailed.split(",").map((data) => (
+                this.props.updateFailed.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>


### PR DESCRIPTION
This PR introduces two small changes:

1. update confirmation list to be an ordered list, which provides the item counts
2. fix non unique key warning for the List component