### PR TITLE
Ccs 4270 bulk edit metadata bugfixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationConfirmation.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationConfirmation.test.tsx.snap
@@ -129,13 +129,19 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
       <List
         aria-label="succeeded"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositories/s/a
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="1"
+        >
           /repositories/s/b
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="2"
+        >
           /repositories/s/c
         </ListItem>
       </List>
@@ -152,10 +158,14 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
       <List
         aria-label="ignored"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositorires/i/a
         </ListItem>
-        <ListItem>
+        <ListItem
+          key="1"
+        >
           /repositorires/i/b
         </ListItem>
       </List>
@@ -172,7 +182,9 @@ exports[`BulkOperationConfirmation tests should render BulkOperationConfirmation
       <List
         aria-label="failed"
       >
-        <ListItem>
+        <ListItem
+          key="0"
+        >
           /repositories/f/a
         </ListItem>
       </List>

--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
@@ -5,14 +5,15 @@ exports[`BulkOperationMetadata tests should render BulkOperationMetadata compone
   <BulkOperationConfirmation
     footer=""
     header="Bulk Edit"
+    isEditMetadata={true}
     onMetadataEditError={[Function]}
-    onShowBulkEditConfirmation={[Function]}
     progressFailureValue={0}
     progressSuccessValue={0}
     progressWarningValue={0}
     subheading="Documents updated in the bulk operation"
     updateFailed=""
     updateIgnored=""
+    updateIsEditMetadata={[Function]}
     updateSucceeded=""
   />
   <Modal

--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`BulkOperationMetadata tests should render BulkOperationMetadata compone
       Array [
         <Button
           form="bulk_edit_metadata"
+          isAriaDisabled={false}
           onClick={[Function]}
           variant="primary"
         >

--- a/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/bulkOperationMetadata.test.tsx.snap
@@ -2,20 +2,6 @@
 
 exports[`BulkOperationMetadata tests should render BulkOperationMetadata component 1`] = `
 <Fragment>
-  <BulkOperationConfirmation
-    footer=""
-    header="Bulk Edit"
-    isEditMetadata={true}
-    onMetadataEditError={[Function]}
-    progressFailureValue={0}
-    progressSuccessValue={0}
-    progressWarningValue={0}
-    subheading="Documents updated in the bulk operation"
-    updateFailed=""
-    updateIgnored=""
-    updateIsEditMetadata={[Function]}
-    updateSucceeded=""
-  />
   <Modal
     actions={
       Array [

--- a/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
@@ -348,6 +348,7 @@ exports[`Search tests should render default Search component 1`] = `
           toggleTextExpanded=""
         >
           <SearchResults
+            bulkOperationCompleted={false}
             contentType="module"
             currentBulkOperation=""
             disabledClassname=""
@@ -376,6 +377,7 @@ exports[`Search tests should render default Search component 1`] = `
           toggleTextExpanded=""
         >
           <SearchResults
+            bulkOperationCompleted={false}
             contentType="assembly"
             currentBulkOperation=""
             disabledClassname=""

--- a/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/search.test.tsx.snap
@@ -253,6 +253,7 @@ exports[`Search tests should render default Search component 1`] = `
             </Select>
           </ToolbarFilter>
         </ForwardRef>
+        .
       </ToolbarToggleGroup>
       <ForwardRef
         variant="icon-button-group"

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
@@ -8,6 +8,7 @@ import { render, fireEvent } from '@testing-library/react'
 const anymatch = require("anymatch")
 
 const props = {
+    isEditMetadata: true,
     header: "Bulk Edit",
     subheading: "Summary",
     updateSucceeded: "/repositories/s/a,/repositories/s/b,/repositories/s/c",
@@ -17,8 +18,9 @@ const props = {
     progressSuccessValue: 50,
     progressFailureValue: 10,
     progressWarningValue: 40,
-    onShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
-    onMetadataEditError: (metadataEditError) => anymatch
+    // onShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
+    onMetadataEditError: (metadataEditError) => anymatch,
+    updateIsEditMetadata: (isEditMetadata) => anymatch
 }
 
 describe("BulkOperationConfirmation tests", () => {

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
@@ -18,7 +18,7 @@ const props = {
     progressSuccessValue: 50,
     progressFailureValue: 10,
     progressWarningValue: 40,
-    // onShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
+    onShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
     onMetadataEditError: (metadataEditError) => anymatch,
     updateIsEditMetadata: (isEditMetadata) => anymatch
 }

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
@@ -4,6 +4,7 @@ import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-t
 import "@app/app.css";
 
 export interface IBulkOperationProps {
+  isEditMetadata: boolean
   header: string
   subheading: string
   updateSucceeded: string
@@ -13,8 +14,9 @@ export interface IBulkOperationProps {
   progressSuccessValue: number
   progressFailureValue: number
   progressWarningValue: number
-  onShowBulkEditConfirmation: (showBulkEditConfirmation) => any
+  // onShowBulkEditConfirmation: (showBulkEditConfirmation) => any
   onMetadataEditError: (metadataEditError) => any
+  updateIsEditMetadata: (isEditMetadata) => any
 }
 
 class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any>{
@@ -75,9 +77,9 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <span id="update-succeeded">
             <List aria-label="succeeded">
               {this.props.updateSucceeded.length > 0 &&
-                this.props.updateSucceeded.split(",").map((data) => (
+                this.props.updateSucceeded.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -88,9 +90,9 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <span id="update-ignored">
             <List aria-label="ignored">
               {this.props.updateIgnored.length > 0 &&
-                this.props.updateIgnored.split(",").map((data) => (
+                this.props.updateIgnored.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -101,9 +103,9 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <span id="update-failed">
             <List aria-label="failed">
               {this.props.updateFailed.length > 0 &&
-                this.props.updateFailed.split(",").map((data) => (
+                this.props.updateFailed.split(",").map((data, index) => (
                   data.length > 0 &&
-                  <ListItem>{data}</ListItem>
+                  <ListItem key={index}>{data}</ListItem>
                 ))}
             </List>
           </span>
@@ -122,10 +124,17 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
   };
 
   private hideAlert = () => {
-    this.props.onShowBulkEditConfirmation(false)
+    // this.props.onShowBulkEditConfirmation(false)
     this.props.onMetadataEditError("")
+    // console.log("[hideAlert] showBulkEditConfirmation: false")
+    // this.updateIsEditMetadata()
     //TODO: refresh documentsSelected
     // this.SearchResults.current.doSearch()
+  }
+
+  private updateIsEditMetadata = () => {
+    // call parent `updateIsEditMetadata` method
+    this.props.updateIsEditMetadata(false)
   }
 }
 

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
@@ -14,7 +14,7 @@ export interface IBulkOperationProps {
   progressSuccessValue: number
   progressFailureValue: number
   progressWarningValue: number
-  // onShowBulkEditConfirmation: (showBulkEditConfirmation) => any
+  onShowBulkEditConfirmation: (showBulkEditConfirmation) => any
   onMetadataEditError: (metadataEditError) => any
   updateIsEditMetadata: (isEditMetadata) => any
 }
@@ -48,20 +48,20 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
 
     return (
       <React.Fragment>
-          <Alert
-            variant="info"
-            title="Bulk Edit"
-            actionClose={<AlertActionCloseButton data-testid="hide-alert-button" onClose={this.hideAlert} />}
-            actionLinks={
-              <React.Fragment>
-                <AlertActionLink data-testid="view-details-link" onClick={this.handleModalToggle}>View details</AlertActionLink>
-              </React.Fragment>
-            }
-          >
-            <div><Progress value={this.props.progressSuccessValue} title="Update Succeeded" variant={ProgressVariant.success} size={ProgressSize.sm} /></div>
-            <div><Progress value={this.props.progressFailureValue} title="Update failed" variant={ProgressVariant.danger} size={ProgressSize.sm} /></div>
-            <div><Progress value={this.props.progressWarningValue} title="No draft version found. No action taken" variant={ProgressVariant.warning} size={ProgressSize.sm} /></div>
-          </Alert>
+        <Alert
+          variant="info"
+          title="Bulk Edit"
+          actionClose={<AlertActionCloseButton data-testid="hide-alert-button" onClose={this.hideAlert} />}
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink data-testid="view-details-link" onClick={this.handleModalToggle}>View details</AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <div><Progress value={this.props.progressSuccessValue} title="Update Succeeded" variant={ProgressVariant.success} size={ProgressSize.sm} /></div>
+          <div><Progress value={this.props.progressFailureValue} title="Update failed" variant={ProgressVariant.danger} size={ProgressSize.sm} /></div>
+          <div><Progress value={this.props.progressWarningValue} title="No draft version found. No action taken" variant={ProgressVariant.warning} size={ProgressSize.sm} /></div>
+        </Alert>
         <Modal
           variant={ModalVariant.large}
           isOpen={isModalOpen}
@@ -124,16 +124,8 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
   };
 
   private hideAlert = () => {
-    // this.props.onShowBulkEditConfirmation(false)
+    this.props.onShowBulkEditConfirmation(false)
     this.props.onMetadataEditError("")
-    // console.log("[hideAlert] showBulkEditConfirmation: false")
-    // this.updateIsEditMetadata()
-    //TODO: refresh documentsSelected
-    // this.SearchResults.current.doSearch()
-  }
-
-  private updateIsEditMetadata = () => {
-    // call parent `updateIsEditMetadata` method
     this.props.updateIsEditMetadata(false)
   }
 }

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
@@ -11,7 +11,9 @@ const props = {
     documentsSelected: anymatch,
     contentTypeSelected: "module",
     isEditMetadata: true,
+    bulkOperationCompleted: false,
     updateIsEditMetadata: (isEditMetadata) => anymatch,
+    updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch
 }
 describe("BulkOperationMetadata tests", () => {
     const api = "/content/products.harray.1.json"

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
@@ -11,8 +11,10 @@ const props = {
     documentsSelected: anymatch,
     contentTypeSelected: "module",
     isEditMetadata: true,
+    showBulkEditConfirmation: true,
     bulkOperationCompleted: false,
     updateIsEditMetadata: (isEditMetadata) => anymatch,
+    updateShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
     updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch
 }
 describe("BulkOperationMetadata tests", () => {
@@ -45,6 +47,7 @@ describe("BulkOperationMetadata tests", () => {
     it("should render an Alert component", () => {
 
         const wrapper = mount(<BulkOperationMetadata {...props} />)
+        wrapper.setState({showBulkEditConfirmation: true})
         const alert = wrapper.find(Alert)
         expect(alert.exists()).toBe(true)
     })
@@ -52,6 +55,7 @@ describe("BulkOperationMetadata tests", () => {
     it("should render an Button component", () => {
 
         const wrapper = mount(<BulkOperationMetadata {...props} />)
+        wrapper.setState({showBulkEditConfirmation: true})
         const button = wrapper.find(Alert)
         expect(button.exists()).toBe(true)
     })

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.test.tsx
@@ -12,9 +12,8 @@ const props = {
     contentTypeSelected: "module",
     isEditMetadata: true,
     showBulkEditConfirmation: true,
-    bulkOperationCompleted: false,
+    bulkOperationCompleted: true,
     updateIsEditMetadata: (isEditMetadata) => anymatch,
-    updateShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
     updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch
 }
 describe("BulkOperationMetadata tests", () => {
@@ -47,7 +46,7 @@ describe("BulkOperationMetadata tests", () => {
     it("should render an Alert component", () => {
 
         const wrapper = mount(<BulkOperationMetadata {...props} />)
-        wrapper.setState({showBulkEditConfirmation: true})
+        wrapper.setState({ showBulkEditConfirmation: true })
         const alert = wrapper.find(Alert)
         expect(alert.exists()).toBe(true)
     })
@@ -55,7 +54,7 @@ describe("BulkOperationMetadata tests", () => {
     it("should render an Button component", () => {
 
         const wrapper = mount(<BulkOperationMetadata {...props} />)
-        wrapper.setState({showBulkEditConfirmation: true})
+        wrapper.setState({ showBulkEditConfirmation: true })
         const button = wrapper.find(Alert)
         expect(button.exists()).toBe(true)
     })

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -80,7 +80,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                     aria-label="Edit metadata"
                     onClose={this.handleModalClose}
                     actions={[
-                        <Button form="bulk_edit_metadata" key="confirm" variant="primary" onClick={this.saveMetadata}>
+                        <Button form="bulk_edit_metadata" isAriaDisabled={this.props.documentsSelected.length === 0 ? true : false} key="confirm" variant="primary" onClick={this.saveMetadata}>
                             Save
                 </Button>,
                         <Button data-testid="metadata-modal-cancel-button" key="cancel" variant="secondary" onClick={this.handleModalToggle}>
@@ -267,7 +267,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
     private onChangeUsecase = (usecaseValue, event) => {
         if (event != undefined) {
             this.setState({ usecaseValue: event.target.value })
-            // console.log("[onChangeUsecase] event.target.value=>", event.target.value)
+
             if (event.target.value !== "" && event.target.value.trim() !== "Select Use Case") {
                 this.setState({ useCaseValidated: "success" })
             } else {
@@ -337,7 +337,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
             formData.append("searchKeywords", this.state.keywords === undefined ? "" : this.state.keywords)
 
             this.props.documentsSelected.map((r) => {
-                // console.log("[saveMetadata] documentsSelected href =>", r.cells[1].title.props.href)
                 if (r.cells[1].title.props.href) {
                     let href = r.cells[1].title.props.href
 
@@ -357,7 +356,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                 method: "post"
                             }).then(response => {
                                 if (response.status === 201 || response.status === 200) {
-                                    // console.log("successful edit ", response.status + " for  path: " + backend)
 
                                     let docs = new Array()
                                     docs = this.state.documentsSucceeded
@@ -372,14 +370,13 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                         productVersionValidated: "error",
                                         useCaseValidated: "error",
                                         bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
-                                        // showBulkEditConfirmation: true,
                                     }, () => {
                                         this.handleModalClose()
-                                        
+
                                         this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
                                     })
                                 } else {
-                                    
+
                                     let docs = new Array()
                                     docs = this.state.documentsFailed
                                     docs.push(docPath)
@@ -392,15 +389,14 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                             })
                         } else {
                             // draft does not exist
-                            // console.log("[saveMetadata] no draft version found:", backend)
                             let docs = new Array()
                             docs = this.state.documentsIgnored
                             docs.push(docPath)
                             this.setState({ bulkUpdateWarning: this.state.bulkUpdateWarning + 1, documentsIgnored: docs }, () => {
-                                
+
                                 this.calculateWarningProgress(this.state.bulkUpdateWarning)
                                 if (this.state.bulkUpdateWarning > 0 && this.state.bulkUpdateWarning === this.props.documentsSelected.length) {
-                                    
+
                                     this.setState({ metadataEditError: "No draft versions found on selected items. Unable to save metadata." })
                                 }
                             })

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -10,7 +10,9 @@ export interface IBulkOperationMetadataProps {
     documentsSelected: Array<{ cells: [string, { title: { props: { href: string } } }, string, string, string], selected: boolean }>
     contentTypeSelected: string
     isEditMetadata: boolean
+    bulkOperationCompleted: boolean
     updateIsEditMetadata: (isEditMetadata) => any
+    updateBulkOperationCompleted: (bulkOperationConfirmation) => any
 }
 
 class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps, any>{
@@ -202,6 +204,9 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                 this.state.documentsFailed.length === 0 &&
                 this.state.documentsIgnored.length === 0) {
                 this.props.updateIsEditMetadata(false)
+            } else {
+                this.props.updateBulkOperationCompleted(true)
+
             }
 
         })
@@ -209,7 +214,11 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
 
     private handleModalToggle = (event) => {
         this.setState({ isModalOpen: !this.state.isModalOpen, showBulkEditConfirmation: false }, () => {
-            this.props.updateIsEditMetadata(false)
+            
+            if (!this.state.isModalOpen) {
+                this.props.updateIsEditMetadata(false)
+                this.props.updateBulkOperationCompleted(true)
+            }
         })
     }
 

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -215,13 +215,11 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                 if (this.state.documentsSucceeded.length > 0 ||
                     this.state.documentsFailed.length > 0 ||
                     this.state.documentsIgnored.length > 0) {
-                        console.log("[handleModalToggle] Save button was clicked")
                         // Save button was clicked. Documents were processed.
                         this.props.updateIsEditMetadata(false)
                         this.props.updateBulkOperationCompleted(true)
                         this.setState({ showBulkEditConfirmation: true })
                 } else {
-                    console.log("[handleModalToggle] Cancel button was clicked")
                     // Cancle button was clicked. Documents were not processed.
                     this.props.updateIsEditMetadata(false)
                     this.props.updateBulkOperationCompleted(false)

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -367,7 +367,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
 
                     // check draft version
                     const backend = "/content" + docPath + "/en_US/variants/" + variant + "/draft/metadata"
-                    // this.setState({ showBulkEditConfirmation: true })
                     Utils.draftExist(backend).then((exist) => {
                         if (exist) {
                             // Process form for each docPath

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -553,7 +553,11 @@ class Search extends Component<IAppState, ISearchState> {
       repositoriesSelected
     }, () => {
       if (this.state.repositoriesSelected.length === 0) {
-        this.setState({ documentsSelected: [], isBulkOperationButtonDisabled: true })
+        this.setState({
+          documentsSelected: [],
+          isBulkOperationButtonDisabled: true,
+          contentTypeSelected: ""
+        })
       }
 
       if (this.state.repositoriesSelected.length === 1 && this.state.editMetadataWarn === true) {
@@ -641,7 +645,11 @@ class Search extends Component<IAppState, ISearchState> {
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
     this.setState({ bulkOperationCompleted }, () => {
       if (this.state.bulkOperationCompleted) {
-        this.setState({ documentsSelected: [], isBulkOperationButtonDisabled: true })
+        this.setState({
+          documentsSelected: [],
+          isBulkOperationButtonDisabled: true,
+          contentTypeSelected: ""
+        })
       }
     })
   }

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -52,8 +52,8 @@ export interface ISearchState {
   repositoriesSelected: string[]
   documentsSelected: Array<{ cells: [string, { title: { props: { href: string } } }, string, string, string], selected: boolean }>
   contentTypeSelected: string
-  isModalOpen: boolean
   isEditMetadata: boolean
+  showBulkEditConfirmation: boolean
   editMetadataWarn: boolean
   isBulkOperationButtonDisabled: boolean
   bulkOperationCompleted: boolean
@@ -96,8 +96,8 @@ class Search extends Component<IAppState, ISearchState> {
       // bulk operation
       documentsSelected: [],
       contentTypeSelected: "",
-      isModalOpen: false,
       isEditMetadata: false,
+      showBulkEditConfirmation: false,
       editMetadataWarn: false,
       isBulkOperationButtonDisabled: true,
       bulkOperationCompleted: false,
@@ -198,6 +198,7 @@ class Search extends Component<IAppState, ISearchState> {
             onSelectContentType={this.bulkEditSectionCheck}
             currentBulkOperation={this.state.contentTypeSelected}
             disabledClassname={this.state.contentTypeSelected == 'assembly' ? 'disabled-search-results' : ''}
+            bulkOperationCompleted={this.state.bulkOperationCompleted}
           />
 
         </ExpandableSection>
@@ -215,6 +216,7 @@ class Search extends Component<IAppState, ISearchState> {
             onSelectContentType={this.bulkEditSectionCheck}
             currentBulkOperation={this.state.contentTypeSelected}
             disabledClassname={this.state.contentTypeSelected == 'module' ? 'disabled-search-results' : ''}
+            bulkOperationCompleted={this.state.bulkOperationCompleted}
           />
 
         </ExpandableSection>
@@ -327,12 +329,14 @@ class Search extends Component<IAppState, ISearchState> {
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody className="search-results">
               {this.state.editMetadataWarn && <Alert variant="danger" isInline title="Attempt to apply the same product/version to multiple repositories is not allowed." />}
-              {this.state.isEditMetadata && <BulkOperationMetadata
+              {(this.state.isEditMetadata || this.state.showBulkEditConfirmation )&& <BulkOperationMetadata
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isEditMetadata={this.state.isEditMetadata}
+                showBulkEditConfirmation={this.state.showBulkEditConfirmation}
                 bulkOperationCompleted={this.state.bulkOperationCompleted}
                 updateIsEditMetadata={this.updateIsEditMetadata}
+                updateShowBulkEditConfirmation={this.updateShowBulkEditConfirmation}
                 updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
               {drawerContent}
@@ -629,10 +633,15 @@ class Search extends Component<IAppState, ISearchState> {
     this.setState({ isEditMetadata: updateIsEditMetadata })
   }
 
+  private updateShowBulkEditConfirmation = (showBulkEditConfirmation) => {
+    this.setState({ showBulkEditConfirmation })
+  }
+
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
     this.setState({ bulkOperationCompleted}, ()=>{
       if(this.state.bulkOperationCompleted){
         // refresh documentsSelected
+        console.log("[updateBulkOperationCompleted] trigger doSearch")
         this.searchResultsRef.current && this.searchResultsRef.current.doSearch()
       }
     })

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -55,7 +55,7 @@ export interface ISearchState {
   isModalOpen: boolean
   isEditMetadata: boolean
   editMetadataWarn: boolean
-  isMetadataButtonDisabled: boolean
+  isBulkOperationButtonDisabled: boolean
 }
 class Search extends Component<IAppState, ISearchState> {
   private drawerRef: React.RefObject<HTMLInputElement>;
@@ -99,7 +99,7 @@ class Search extends Component<IAppState, ISearchState> {
       isModalOpen: false,
       isEditMetadata: false,
       editMetadataWarn: false,
-      isMetadataButtonDisabled: true,
+      isBulkOperationButtonDisabled: true,
     };
     this.drawerRef = React.createRef();
 
@@ -299,7 +299,7 @@ class Search extends Component<IAppState, ISearchState> {
         <ToolbarGroup variant="icon-button-group">
         </ToolbarGroup>
         {this.props.userAuthenticated && (this.props.isAuthor || this.props.isPublisher || this.props.isAdmin) && <ToolbarItem>
-          <Button variant="primary" isAriaDisabled={this.state.isMetadataButtonDisabled || this.state.repositoriesSelected.length === 0} onClick={this.handleEditMetadata} data-testid="edit_metadata">Edit metadata</Button>
+          <Button variant="primary" isAriaDisabled={this.state.isBulkOperationButtonDisabled || this.state.repositoriesSelected.length === 0} onClick={this.handleEditMetadata} data-testid="edit_metadata">Edit metadata</Button>
         </ToolbarItem>}
         {this.props.userAuthenticated && (this.props.isPublisher || this.props.isAdmin) && <ToolbarItem>
           <Button variant="primary" isAriaDisabled={true}>Publish</Button>
@@ -545,7 +545,7 @@ class Search extends Component<IAppState, ISearchState> {
       repositoriesSelected
     }, () => {
       if (this.state.repositoriesSelected.length === 0) {
-        this.setState({ documentsSelected: [], isMetadataButtonDisabled: true })
+        this.setState({ documentsSelected: [], isBulkOperationButtonDisabled: true })
       }
 
       if (this.state.repositoriesSelected.length === 1 && this.state.editMetadataWarn === true) {
@@ -584,14 +584,14 @@ class Search extends Component<IAppState, ISearchState> {
       this.setState({
         contentTypeSelected: '',
         documentsSelected: [],
-        isMetadataButtonDisabled: true
+        isBulkOperationButtonDisabled: true
       })
     } else {
       this.setState({ documentsSelected }, () => {
         if (this.state.documentsSelected.length > 0) {
-          this.setState({ isMetadataButtonDisabled: false })
+          this.setState({ isBulkOperationButtonDisabled: false })
         } else {
-          this.setState({ isMetadataButtonDisabled: true })
+          this.setState({ isBulkOperationButtonDisabled: true })
         }
       })
     }
@@ -605,7 +605,7 @@ class Search extends Component<IAppState, ISearchState> {
   private handleEditMetadata = (event) => {
     if (this.state.repositoriesSelected.length > 1) {
       this.setState({ editMetadataWarn: true }, () => {
-        this.setState({ isMetadataButtonDisabled: true })
+        this.setState({ isBulkOperationButtonDisabled: true })
       })
     } else {
       this.setState({
@@ -613,9 +613,9 @@ class Search extends Component<IAppState, ISearchState> {
         editMetadataWarn: false
       }, () => {
         if (this.state.editMetadataWarn === false && this.state.repositoriesSelected.length === 1) {
-          this.setState({ isMetadataButtonDisabled: false })
+          this.setState({ isBulkOperationButtonDisabled: false })
         } else {
-          this.setState({ isMetadataButtonDisabled: true })
+          this.setState({ isBulkOperationButtonDisabled: true })
         }
       })
     }

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -52,10 +52,9 @@ export interface ISearchState {
   // metadata
   productsSelected: string[]
   repositoriesSelected: string[]
-  documentsSelected: Array<{ cells: [string, { title: { props: {children: string[], href: string } } }, string, string, string], selected: boolean }>
+  documentsSelected: Array<{ cells: [string, { title: { props: { children: string[], href: string } } }, string, string, string], selected: boolean }>
   contentTypeSelected: string
   isEditMetadata: boolean
-  showBulkEditConfirmation: boolean
   editMetadataWarn: boolean
   isBulkOperationButtonDisabled: boolean
   bulkOperationCompleted: boolean
@@ -65,10 +64,9 @@ export interface ISearchState {
 }
 class Search extends Component<IAppState, ISearchState> {
   private drawerRef: React.RefObject<HTMLInputElement>;
-  private searchResultsRef;
 
   constructor(props) {
-    super(props);   
+    super(props);
     this.state = {
       // states for drawer
       filterLabel: "repo",
@@ -102,7 +100,6 @@ class Search extends Component<IAppState, ISearchState> {
       documentsSelected: [],
       contentTypeSelected: "",
       isEditMetadata: false,
-      showBulkEditConfirmation: false,
       editMetadataWarn: false,
       isBulkOperationButtonDisabled: true,
       bulkOperationCompleted: false,
@@ -111,7 +108,6 @@ class Search extends Component<IAppState, ISearchState> {
       isBulkPublish: false
     };
     this.drawerRef = React.createRef();
-    this.searchResultsRef = React.createRef();
   }
 
   public componentDidMount() {
@@ -136,11 +132,6 @@ class Search extends Component<IAppState, ISearchState> {
     // TODO: enable resize
     // toolbar
     // window.removeEventListener("resize", this.closeExpandableContent);
-  }
-
-  public componentDidUpdate(prevProps) {
-    
-
   }
 
   public render() {
@@ -196,7 +187,6 @@ class Search extends Component<IAppState, ISearchState> {
       <React.Fragment>
         <ExpandableSection toggleText="Modules" className="pf-c-title search-results__section search-results__section--module" isActive={true} isExpanded={modulesIsExpanded} onToggle={this.onModulesToggle}>
           <SearchResults
-            ref={this.searchResultsRef}
             contentType="module"
             keyWord={this.state.inputValue}
             repositoriesSelected={this.state.repositoriesSelected}
@@ -214,7 +204,6 @@ class Search extends Component<IAppState, ISearchState> {
         <br />
         <ExpandableSection toggleText="Assemblies" className="pf-c-title search-results__section search-results__section--assembly" isActive={true} isExpanded={assembliesIsExpanded} onToggle={this.onAssembliesToggle}>
           <SearchResults
-            ref={this.searchResultsRef}
             contentType="assembly"
             keyWord={this.state.inputValue}
             repositoriesSelected={this.state.repositoriesSelected}
@@ -338,17 +327,15 @@ class Search extends Component<IAppState, ISearchState> {
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody className="search-results">
               {this.state.editMetadataWarn && <Alert variant="danger" isInline title="Attempt to apply the same product/version to multiple repositories is not allowed." />}
-              {(this.state.isEditMetadata || this.state.showBulkEditConfirmation )&& <BulkOperationMetadata
+              {(this.state.isEditMetadata || this.state.bulkOperationCompleted) && <BulkOperationMetadata
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isEditMetadata={this.state.isEditMetadata}
-                showBulkEditConfirmation={this.state.showBulkEditConfirmation}
                 bulkOperationCompleted={this.state.bulkOperationCompleted}
                 updateIsEditMetadata={this.updateIsEditMetadata}
-                updateShowBulkEditConfirmation={this.updateShowBulkEditConfirmation}
                 updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
-              {this.state.isBulkPublish && <BulkOperationPublish 
+              {this.state.isBulkPublish && <BulkOperationPublish
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isBulkPublish={this.state.isBulkPublish}
@@ -626,7 +613,7 @@ class Search extends Component<IAppState, ISearchState> {
   private handleEditMetadata = (event) => {
     if (this.state.repositoriesSelected.length > 1) {
       this.setState({ editMetadataWarn: true }, () => {
-        this.setState({ isBulkOperationButtonDisabled: true })
+        this.setState({ isBulkOperationButtonDisabled: true, bulkOperationCompleted: false })
       })
     } else {
       this.setState({
@@ -634,7 +621,7 @@ class Search extends Component<IAppState, ISearchState> {
         editMetadataWarn: false
       }, () => {
         if (this.state.editMetadataWarn === false && this.state.repositoriesSelected.length === 1) {
-          this.setState({ isBulkOperationButtonDisabled: false })
+          this.setState({ isBulkOperationButtonDisabled: false, bulkOperationCompleted: false })
         } else {
           this.setState({ isBulkOperationButtonDisabled: true })
         }
@@ -646,30 +633,21 @@ class Search extends Component<IAppState, ISearchState> {
   private handleBulkPublish = (event) => {
     this.setState({ isBulkPublish: !this.state.isBulkPublish })
   }
-  
+
   private updateIsEditMetadata = (updateIsEditMetadata) => {
     this.setState({ isEditMetadata: updateIsEditMetadata })
   }
 
-  private updateShowBulkEditConfirmation = (showBulkEditConfirmation) => {
-    this.setState({ showBulkEditConfirmation })
-  }
-
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
-    this.setState({ bulkOperationCompleted}, ()=>{
-      if(this.state.bulkOperationCompleted){
-        this.setState({documentsSelected: []})
-        
-        // refresh documentsSelected
-        console.log("[updateBulkOperationCompleted] trigger doSearch")
-        this.searchResultsRef.current.doSearch()
-        
+    this.setState({ bulkOperationCompleted }, () => {
+      if (this.state.bulkOperationCompleted) {
+        this.setState({ documentsSelected: [], isBulkOperationButtonDisabled: true })
       }
     })
   }
 
   private updateIsBulkPublish = updateIsBulkPublish => {
-    this.setState({isBulkPublish: updateIsBulkPublish})
+    this.setState({ isBulkPublish: updateIsBulkPublish })
   }
 
 }

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -56,14 +56,14 @@ export interface ISearchState {
   isEditMetadata: boolean
   editMetadataWarn: boolean
   isBulkOperationButtonDisabled: boolean
+  bulkOperationCompleted: boolean
 }
 class Search extends Component<IAppState, ISearchState> {
   private drawerRef: React.RefObject<HTMLInputElement>;
-  private SearchResults;
+  private searchResultsRef;
 
   constructor(props) {
-    super(props);
-    this.SearchResults = React.createRef();
+    super(props);   
     this.state = {
       // states for drawer
       filterLabel: "repo",
@@ -100,9 +100,10 @@ class Search extends Component<IAppState, ISearchState> {
       isEditMetadata: false,
       editMetadataWarn: false,
       isBulkOperationButtonDisabled: true,
+      bulkOperationCompleted: false,
     };
     this.drawerRef = React.createRef();
-
+    this.searchResultsRef = React.createRef();
   }
 
   public componentDidMount() {
@@ -130,7 +131,7 @@ class Search extends Component<IAppState, ISearchState> {
   }
 
   public componentDidUpdate(prevProps) {
-
+    
   }
 
   public render() {
@@ -186,7 +187,7 @@ class Search extends Component<IAppState, ISearchState> {
       <React.Fragment>
         <ExpandableSection toggleText="Modules" className="pf-c-title search-results__section search-results__section--module" isActive={true} isExpanded={modulesIsExpanded} onToggle={this.onModulesToggle}>
           <SearchResults
-            ref={this.SearchResults}
+            ref={this.searchResultsRef}
             contentType="module"
             keyWord={this.state.inputValue}
             repositoriesSelected={this.state.repositoriesSelected}
@@ -203,7 +204,7 @@ class Search extends Component<IAppState, ISearchState> {
         <br />
         <ExpandableSection toggleText="Assemblies" className="pf-c-title search-results__section search-results__section--assembly" isActive={true} isExpanded={assembliesIsExpanded} onToggle={this.onAssembliesToggle}>
           <SearchResults
-            ref={this.SearchResults}
+            ref={this.searchResultsRef}
             contentType="assembly"
             keyWord={this.state.inputValue}
             repositoriesSelected={this.state.repositoriesSelected}
@@ -330,7 +331,9 @@ class Search extends Component<IAppState, ISearchState> {
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isEditMetadata={this.state.isEditMetadata}
+                bulkOperationCompleted={this.state.bulkOperationCompleted}
                 updateIsEditMetadata={this.updateIsEditMetadata}
+                updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
               {drawerContent}
 
@@ -624,6 +627,15 @@ class Search extends Component<IAppState, ISearchState> {
 
   private updateIsEditMetadata = (updateIsEditMetadata) => {
     this.setState({ isEditMetadata: updateIsEditMetadata })
+  }
+
+  private updateBulkOperationCompleted = (bulkOperationCompleted) => {
+    this.setState({ bulkOperationCompleted}, ()=>{
+      if(this.state.bulkOperationCompleted){
+        // refresh documentsSelected
+        this.searchResultsRef.current && this.searchResultsRef.current.doSearch()
+      }
+    })
   }
 }
 

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -658,9 +658,12 @@ class Search extends Component<IAppState, ISearchState> {
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
     this.setState({ bulkOperationCompleted}, ()=>{
       if(this.state.bulkOperationCompleted){
+        this.setState({documentsSelected: []})
+        
         // refresh documentsSelected
         console.log("[updateBulkOperationCompleted] trigger doSearch")
-        this.searchResultsRef.current && this.searchResultsRef.current.doSearch()
+        this.searchResultsRef.current.doSearch()
+        
       }
     })
   }

--- a/pantheon-bundle/frontend/src/app/searchResults.test.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.test.tsx
@@ -22,7 +22,8 @@ const props = {
     onGetdocumentsSelected: (documentsSelected) => anymatch,
     onSelectContentType: (contentType) => anymatch,
     currentBulkOperation: "",
-    disabledClassname: ""
+    disabledClassname: "",
+    bulkOperationCompleted: false,
 }
 
 const propsEmptyState = {
@@ -35,8 +36,8 @@ const propsEmptyState = {
     onGetdocumentsSelected: (documentsSelected) => anymatch,
     onSelectContentType: (contentType) => anymatch,
     currentBulkOperation: "",
-    disabledClassname: ""
-
+    disabledClassname: "",
+    bulkOperationCompleted: false,
 }
 
 describe("SearchResults tests", () => {

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -34,6 +34,7 @@ export interface IProps {
   onSelectContentType: (contentType) => any
   currentBulkOperation: string
   disabledClassname: string
+  bulkOperationCompleted: boolean
 }
 export interface ISearchState {
 
@@ -122,6 +123,7 @@ class SearchResults extends Component<IProps, ISearchState> {
       || this.props.keyWord !== prevProps.keyWord
       || this.props.filters !== prevProps.filters
       || this.props.onGetdocumentsSelected !== prevProps.onGetdocumentsSelected
+      || this.props.bulkOperationCompleted !== prevProps.bulkOperationCompleted
     ) {
       this.doSearch()
     }

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -350,7 +350,6 @@ class SearchResults extends Component<IProps, ISearchState> {
     this.setState({
       rows
     });
-    // console.log("[onSelect] bulkSelected rows =>", rows)
     // update props.documentSelected
     let selectedRows;
     selectedRows = this.state.rows.map(oneRow => {
@@ -360,10 +359,9 @@ class SearchResults extends Component<IProps, ISearchState> {
     })
     // filter undefined values
     selectedRows = selectedRows.filter(r => r !== undefined)
-    // console.log("[onSelect] bulkSelected selectedRows =>", selectedRows)
-    if (selectedRows.length > 0) {
-      this.props.onGetdocumentsSelected(selectedRows);
-    }
+
+    this.props.onGetdocumentsSelected(selectedRows);
+
     if (selectedRows.length > 0 || isSelected == true) {
       this.props.onSelectContentType(this.props.contentType);
     }


### PR DESCRIPTION
This PR addresses the following issues:

- update the icon after bulk edit metadata
- fix the grayed out section after bulk edit metadata
- fix the double click issue when users attempt to bulk edit again after completes a previous bulk edit