### PR TITLE
bulk operation button double click fix

### DIFF
--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -687,6 +687,13 @@ class Search extends Component<IAppState, ISearchState> {
   }
 
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
+    //when closing bulk operation modal and no bulk operation was completed, reset bulk operations to false
+    if(!bulkOperationCompleted){
+      this.setState({
+        isBulkPublish: false,
+        isBulkUnpublish: false,
+      })
+    }
     this.setState({ bulkOperationCompleted }, () => {
       if (this.state.bulkOperationCompleted) {
         this.setState({


### PR DESCRIPTION
previously when a user closed a publish/unpublish modal, and then tried to click another bulk operation button, they would have to click twice in order for the modal to appear. Now the button just needs one click