### PR TITLE
CCS-4344-confirmation_updates

### DIFF
--- a/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType, ListVariant } from '@patternfly/react-core';
 import "@app/app.css";
 
 export interface IBulkPublishProps {
@@ -74,47 +74,45 @@ class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
           <strong>{`${this.props.isBulkUnpublish ? "Unpublished" : "Published"} Succeessfully:`}</strong>
           <br />
           <span id="update-succeeded">
-            <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
-              {this.props.updateSucceeded.length > 0 &&
-                this.props.updateSucceeded.split(",").map((data, index) => (
-                  data.length > 0 &&
-                  <ListItem key={index}>{data}</ListItem>
-                ))}
-              {this.props.updateSucceeded.length === 0 &&
-                <ListItem key={"succeeded-0"}>n/a</ListItem>
-              }
-            </List>
+            {this.props.updateSucceeded.length > 0 && <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
+              {this.props.updateSucceeded.split(",").map((data, index) => (
+                data.length > 0 &&
+                <ListItem key={index}>{data}</ListItem>
+              ))}
+            </List>}
+            {this.props.updateSucceeded.length === 0 && <List aria-label="succeeded-empty" variant={ListVariant.inline}>
+              <ListItem key={"succeeded-0"}>n/a</ListItem>
+            </List>}
           </span>
           <br />
           <br />
           {!this.props.isBulkUnpublish && (<div><strong>Publish Ignored:</strong>
             <span id="update-ignored">
-              <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
-                {this.props.updateIgnored.length > 0 &&
-                  this.props.updateIgnored.split(",").map((data, index) => (
-                    data.length > 0 &&
-                    <ListItem key={index}>{data}</ListItem>
-                  ))}
-                {this.props.updateIgnored.length === 0 &&
-                  <ListItem key={"ignored-0"}>n/a</ListItem>
-                }
-              </List>
+              {this.props.updateIgnored.length > 0 && <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
+                {this.props.updateIgnored.split(",").map((data, index) => (
+                  data.length > 0 &&
+                  <ListItem key={index}>{data}</ListItem>
+                ))}
+              </List>}
+              {this.props.updateIgnored.length === 0 && <List aria-label="ignored-empty" variant={ListVariant.inline}>
+                <ListItem key={"ignored-0"}>n/a</ListItem>
+              </List>}
             </span></div>)}
           <br />
           <br />
           <strong>{`${this.props.isBulkUnpublish ? "Unpublish" : "Publish"} Failed:`}</strong>
           <br />
           <span id="update-failed">
-            <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
-              {this.props.updateFailed.length > 0 &&
-                this.props.updateFailed.split(",").map((data, index) => (
-                  data.length > 0 &&
-                  <ListItem key={index}>{data}</ListItem>
-                ))}
-              {this.props.updateFailed.length === 0 &&
-                <ListItem key={"failed-0"}>n/a</ListItem>
-              }
+            {this.props.updateFailed.length > 0 && <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
+              {this.props.updateFailed.split(",").map((data, index) => (
+                data.length > 0 &&
+                <ListItem key={index}>{data}</ListItem>
+              ))}
+            </List>}
+            {this.props.updateFailed.length === 0 && <List aria-label="failed-empty" variant={ListVariant.inline}>
+              <ListItem key={"failed-0"}>n/a</ListItem>
             </List>
+            }
           </span>
           <br />
           <br />

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleSizes, AlertActionCloseButton, Alert, AlertActionLink, Progress, ProgressVariant, ProgressSize, List, ListItem, ProgressMeasureLocation, ListComponent, OrderType, ListVariant } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 import "@app/app.css";
 
@@ -75,48 +75,47 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
           <strong>Update Succeeded:</strong>
           <br />
           <span id="update-succeeded">
-            <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
-              {this.props.updateSucceeded.length > 0 &&
-                this.props.updateSucceeded.split(",").map((data, index) => (
-                  data.length > 0 &&
-                  <ListItem key={index}>{data}</ListItem>
-                ))}
-              {this.props.updateSucceeded.length === 0 &&
-                <ListItem key={"succeeded-0"}>n/a</ListItem>
-              }
-            </List>
+            {this.props.updateSucceeded.length > 0 && <List aria-label="succeeded" component={ListComponent.ol} type={OrderType.number}>
+              {this.props.updateSucceeded.split(",").map((data, index) => (
+                data.length > 0 &&
+                <ListItem key={index}>{data}</ListItem>
+              ))}
+
+            </List>}
+            {this.props.updateSucceeded.length === 0 && <List aria-label="succeeded-empty" variant={ListVariant.inline}>
+              <ListItem key={"succeeded-0"}>n/a</ListItem>
+            </List>}
           </span>
           <br />
           <br />
           <strong>Update Ignored:</strong>
           <br />
           <span id="update-ignored">
-            <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
-              {this.props.updateIgnored.length > 0 &&
-                this.props.updateIgnored.split(",").map((data, index) => (
-                  data.length > 0 &&
-                  <ListItem key={index}>{data}</ListItem>
-                ))}
-              {this.props.updateIgnored.length === 0 &&
-                <ListItem key={"ignored-0"}>n/a</ListItem>
-              }
-            </List>
+            {this.props.updateIgnored.length > 0 && <List aria-label="ignored" component={ListComponent.ol} type={OrderType.number}>
+              {this.props.updateIgnored.split(",").map((data, index) => (
+                data.length > 0 &&
+                <ListItem key={index}>{data}</ListItem>
+              ))}
+            </List>}
+            {this.props.updateIgnored.length === 0 && <List aria-label="ignored-empty" variant={ListVariant.inline}>
+              <ListItem key={"ignored-0"}>n/a</ListItem>
+            </List>}
           </span>
           <br />
           <br />
           <strong>Update Failed:</strong>
           <br />
           <span id="update-failed">
-            <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
-              {this.props.updateFailed.length > 0 &&
-                this.props.updateFailed.split(",").map((data, index) => (
-                  data.length > 0 &&
-                  <ListItem key={index}>{data}</ListItem>
-                ))}
-              {this.props.updateFailed.length === 0 &&
-                <ListItem key={"failed-0"}>n/a</ListItem>
-              }
+            {this.props.updateFailed.length > 0 && <List aria-label="failed" component={ListComponent.ol} type={OrderType.number}>
+              {this.props.updateFailed.split(",").map((data, index) => (
+                data.length > 0 &&
+                <ListItem key={index}>{data}</ListItem>
+              ))}
+            </List>}
+            {this.props.updateFailed.length === 0 && <List aria-label="failed-empty" variant={ListVariant.inline}>
+              <ListItem key={"failed-0"}>n/a</ListItem>
             </List>
+            }
           </span>
           <br />
           <br />


### PR DESCRIPTION
This PR addresses a QA concern. 
* When the list is empty, render "n/a" 
* When list is not empty, render an ordered list 