### PR TITLE
CCS-4359-button_click_issues_on_republish

### DIFF
--- a/pantheon-bundle/frontend/src/app/BulkOperationPublish.test.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkOperationPublish.test.tsx
@@ -12,9 +12,10 @@ const props = {
     contentTypeSelected: "module",
     isBulkPublish: true,
     isBulkUnpublish: false,
-    updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch,
-    bulkOperationCompleted: true
+    bulkOperationCompleted: true,
+    updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch
 }
+
 describe("BulkOperationPublish tests", () => {
     const api = "/content/products.harray.1.json"
 

--- a/pantheon-bundle/frontend/src/app/BulkOperationPublish.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkOperationPublish.tsx
@@ -10,8 +10,8 @@ export interface IBulkOperationPublishProps {
     contentTypeSelected: string
     isBulkPublish: boolean
     isBulkUnpublish: boolean
-    updateBulkOperationCompleted: (bulkOperationConfirmation) => any
     bulkOperationCompleted: boolean
+    updateBulkOperationCompleted: (bulkOperationConfirmation) => any
 }
 
 class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, any>{
@@ -116,6 +116,7 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
             <React.Fragment>
                 {this.state.showBulkConfirmation &&
                     <BulkPublishConfirmation
+                        key={new Date().getTime()}
                         header={this.props.isBulkPublish ? "Bulk Publish" : "Bulk Unpublish"}
                         subheading="Documents updated in the bulk operation"
                         updateSucceeded={this.state.confirmationSucceeded}
@@ -127,6 +128,8 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                         progressWarningValue={this.state.progressWarningValue}
                         onShowBulkOperationConfirmation={this.updateShowBulkPublishConfirmation}
                         isBulkUnpublish={this.props.isBulkUnpublish}
+                        bulkOperationCompleted={this.props.bulkOperationCompleted}
+                        updateBulkOperationCompleted={this.props.updateBulkOperationCompleted}
                     />}
 
                 {this.props.isBulkPublish && publishModal}
@@ -160,6 +163,18 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
         
         formData.append("locale", "en_US")
 
+        // reinitialize states
+        if (this.props.documentsSelected.length > 0) {
+            this.setState({
+                documentsSucceeded: [],
+                documentsFailed: [""],
+                documentsIgnored: [""],
+                confirmationSucceeded: "",
+                confirmationIgnored: "",
+                confirmationFailed: "",
+            });
+        }
+
         this.props.documentsSelected.map((r) => {
             if (r.cells[1].title.props.href) {
                 let href = r.cells[1].title.props.href
@@ -183,7 +198,6 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                                     bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
                                 }, () => {
                                     this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
-                                    this.props.updateBulkOperationCompleted(true)
                                 }
                                 )
                             } else {
@@ -203,7 +217,9 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
             }
 
         })
-        this.setState({ isModalOpen: false, showBulkConfirmation: true })
+        this.setState({ isModalOpen: false, showBulkConfirmation: true }, ()=>{
+            this.props.updateBulkOperationCompleted(true)
+        })
     }
 
     //functions for success & failure messages

--- a/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkPublishConfirmation.tsx
@@ -14,6 +14,8 @@ export interface IBulkPublishProps {
   progressWarningValue: number
   onShowBulkOperationConfirmation: (showBulkConfirmation) => any
   isBulkUnpublish: boolean
+  bulkOperationCompleted: boolean
+  updateBulkOperationCompleted: (bulkOperationCompleted) => any
 }
 
 class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
@@ -130,6 +132,12 @@ class BulkPublishConfirmation extends React.Component<IBulkPublishProps, any>{
 
   private hideAlert = () => {
     this.props.onShowBulkOperationConfirmation(false)
+    // set bulkOperationCompleted to false
+    this.updateBulkOperationCompleted(false)
+  }
+
+  private updateBulkOperationCompleted = (bulkOperationCompleted) => {
+    this.props.updateBulkOperationCompleted(bulkOperationCompleted)
   }
 }
 

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -657,29 +657,38 @@ class Search extends Component<IAppState, ISearchState> {
   }
 
   private handleBulkPublish = (text) => {
-    this.setState({ isEditMetadata: false, bulkOperationCompleted: false })
+    this.setState({ isEditMetadata: false })
     //handle warning if bulk publish/unpublish attempted on > 1 repo
     if (this.state.repositoriesSelected.length > 1) {
       this.setState({ bulkOperationWarn: true }, () => {
-        this.setState({ isBulkOperationButtonDisabled: true })
+        this.setState({ isBulkOperationButtonDisabled: true, bulkOperationCompleted: false })
       })
     } else {
       this.setState({
         bulkOperationWarn: false
       }, () => {
-        if (this.state.bulkOperationWarn === false && this.state.repositoriesSelected.length === 1) {
-          this.setState({ isBulkOperationButtonDisabled: false })
-          //determine if publish or unpublish bulk operation
-          if (text == 'publish') {
-            this.setState({ isBulkPublish: !this.state.isBulkPublish, isBulkUnpublish: false })
-          }
-          if (text == 'unpublish') {
-            this.setState({ isBulkUnpublish: !this.state.isBulkUnpublish, isBulkPublish: false })
 
-          }
-        } else {
-          this.setState({ isBulkOperationButtonDisabled: true })
+        //determine if publish or unpublish bulk operation
+        if (text == 'publish') {
+          this.setState({ isBulkPublish: !this.state.isBulkPublish, isBulkUnpublish: false }, () => {
+            if (this.state.bulkOperationWarn === false && this.state.repositoriesSelected.length === 1) {
+              this.setState({ isBulkOperationButtonDisabled: false, bulkOperationCompleted: false })
+            } else {
+              this.setState({ isBulkOperationButtonDisabled: true })
+            }
+          })
         }
+        else if (text == 'unpublish') {
+          this.setState({ isBulkUnpublish: !this.state.isBulkUnpublish, isBulkPublish: false }, () => {
+            if (this.state.bulkOperationWarn === false && this.state.repositoriesSelected.length === 1) {
+              this.setState({ isBulkOperationButtonDisabled: false, bulkOperationCompleted: false })
+            } else {
+              this.setState({ isBulkOperationButtonDisabled: true })
+            }
+          })
+
+        }
+
       })
     }
 

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -278,7 +278,7 @@ class SearchResults extends Component<IProps, ISearchState> {
 
           responseJSON.results.map((item, key) => {
             const lastUpdateDate = item["pant:publishedDate"]
-            
+
             let docIcon = lastUpdateDate !== "-" ? <div><Tooltip position="top" content={<div>Published successfully</div>}><CheckCircleIcon className="p2-search__check-circle-icon" /></Tooltip></div> : null
             if (docIcon === null) {
               const productVersion = item["productVersion"] != undefined ? item["productVersion"] : "-"
@@ -297,7 +297,7 @@ class SearchResults extends Component<IProps, ISearchState> {
               let docTitle = item["jcr:title"] !== "-" ? item["jcr:title"] : item["pant:transientPath"]
               cellItem.push(docTitle)
             }
-        { title: "Last Published Date" }
+            { title: "Last Published Date" }
             cellItem.push(item["pant:transientSourceName"])
             cellItem.push(item["pant:dateUploaded"])
             cellItem.push(lastUpdateDate)


### PR DESCRIPTION
This PR address the following issues:
  * when performance bulk publish/unpublish more than once on the same repo, the first click clears checkboxes selected
  * when bulk publish multiple documents where one of them has missing metadata, published icons are not updated after the bulk operation completed