### PR TITLE
CCS-3997 Aligning dates on doc detail pages

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/contentDisplay.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/contentDisplay.test.tsx.snap
@@ -53,6 +53,10 @@ exports[`ContentDisplay tests for Assembly should render ContentDisplay componen
               Product
             </span>
           </strong>
+          <br />
+          <span>
+             
+          </span>
         </Text>
       </TextContent>
     </LevelItem>
@@ -67,6 +71,8 @@ exports[`ContentDisplay tests for Assembly should render ContentDisplay componen
               Module type
             </span>
           </strong>
+          <br />
+          <span />
         </Text>
       </TextContent>
     </LevelItem>
@@ -80,6 +86,10 @@ exports[`ContentDisplay tests for Assembly should render ContentDisplay componen
               First Published Date
             </span>
           </strong>
+          <br />
+          <span>
+            --
+          </span>
         </Text>
       </TextContent>
     </LevelItem>
@@ -93,40 +103,7 @@ exports[`ContentDisplay tests for Assembly should render ContentDisplay componen
               Last Published Date
             </span>
           </strong>
-        </Text>
-      </TextContent>
-    </LevelItem>
-  </Level>
-  <Level>
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span>
-             
-          </span>
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem />
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span />
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span>
-            --
-          </span>
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem>
-      <TextContent>
-        <Text>
+          <br />
           <span>
             --
           </span>
@@ -233,6 +210,10 @@ exports[`ContentDisplay tests for Module should render ModuleDisplay component 1
               Product
             </span>
           </strong>
+          <br />
+          <span>
+             
+          </span>
         </Text>
       </TextContent>
     </LevelItem>
@@ -247,6 +228,8 @@ exports[`ContentDisplay tests for Module should render ModuleDisplay component 1
               Module type
             </span>
           </strong>
+          <br />
+          <span />
         </Text>
       </TextContent>
     </LevelItem>
@@ -260,6 +243,10 @@ exports[`ContentDisplay tests for Module should render ModuleDisplay component 1
               First Published Date
             </span>
           </strong>
+          <br />
+          <span>
+            --
+          </span>
         </Text>
       </TextContent>
     </LevelItem>
@@ -273,40 +260,7 @@ exports[`ContentDisplay tests for Module should render ModuleDisplay component 1
               Last Published Date
             </span>
           </strong>
-        </Text>
-      </TextContent>
-    </LevelItem>
-  </Level>
-  <Level>
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span>
-             
-          </span>
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem />
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span />
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem>
-      <TextContent>
-        <Text>
-          <span>
-            --
-          </span>
-        </Text>
-      </TextContent>
-    </LevelItem>
-    <LevelItem>
-      <TextContent>
-        <Text>
+          <br />
           <span>
             --
           </span>

--- a/pantheon-bundle/frontend/src/app/contentDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/contentDisplay.tsx
@@ -127,38 +127,20 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                 <Level>
                     <LevelItem>
                         <TextContent>
-                            <Text><strong><span id="span-source-type-product">Product</span></strong></Text>
+                            <Text>
+                                <strong><span id="span-source-type-product">Product</span></strong>
+                                <br />
+                                <span>{this.state.productValue + " " + this.state.versionValue}</span>
+                            </Text>
                         </TextContent>
                     </LevelItem>
                     <LevelItem>{ }</LevelItem>
 
-                    {!this.isAssembly && <LevelItem>
-                        <TextContent>
-                            <Text><strong><span id="span-source-name-module-type">Module type</span></strong></Text>
-                        </TextContent>
-                    </LevelItem>}
-                    <LevelItem>
-                        <TextContent>
-                            <Text><strong><span id="span-source-type-firstpublished">First Published Date</span></strong></Text>
-                        </TextContent>
-                    </LevelItem>
-                    <LevelItem>
-                        <TextContent>
-                            <Text><strong><span id="span-source-type-lastpublished">Last Published Date</span></strong></Text>
-                        </TextContent>
-                    </LevelItem>
-                </Level>
-
-                <Level>
-                    <LevelItem>
-                        <TextContent>
-                            <Text><span>{this.state.productValue + " " + this.state.versionValue}</span></Text>
-                        </TextContent>
-                    </LevelItem>
-                    <LevelItem>{ }</LevelItem>
                     {!this.isAssembly && <LevelItem>
                         <TextContent>
                             <Text>
+                                <strong><span id="span-source-name-module-type">Module type</span></strong>
+                                <br />
                                 <span>
                                     {this.state.moduleType.trim() !== "" ?
                                         this.state.moduleType : ""}
@@ -169,6 +151,8 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                     <LevelItem>
                         <TextContent>
                             <Text>
+                                <strong><span id="span-source-type-firstpublished">First Published Date</span></strong>
+                                <br />
                                 <span>
                                     {this.state.firstPublishDate.trim() !== ""
                                         && this.state.firstPublishDate.length >= 15 ?
@@ -180,6 +164,8 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                     <LevelItem>
                         <TextContent>
                             <Text>
+                                <strong><span id="span-source-type-lastpublished">Last Published Date</span></strong>
+                                <br />
                                 <span>
                                     {this.state.lastPublishDate.trim() !== ""
                                         && this.state.lastPublishDate.length >= 15 ?


### PR DESCRIPTION
Pournima noted that "Module Type" and "First Publish Date" headers were out of alignment with their values. This fixes that.