### PR TITLE
repopulate icons after closing of confirmation

### DIFF
--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.test.tsx
@@ -18,6 +18,8 @@ const props = {
     progressSuccessValue: 50,
     progressFailureValue: 10,
     progressWarningValue: 40,
+    bulkOperationCompleted: true,
+    updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch,
     onShowBulkEditConfirmation: (showBulkEditConfirmation) => anymatch,
     onMetadataEditError: (metadataEditError) => anymatch,
     updateIsEditMetadata: (isEditMetadata) => anymatch,

--- a/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationConfirmation.tsx
@@ -14,6 +14,8 @@ export interface IBulkOperationProps {
   progressSuccessValue: number
   progressFailureValue: number
   progressWarningValue: number
+  bulkOperationCompleted: boolean
+  updateBulkOperationCompleted: (bulkOperationCompleted) => any
   onShowBulkEditConfirmation: (showBulkEditConfirmation) => any
   onMetadataEditError: (metadataEditError) => any
   updateIsEditMetadata: (isEditMetadata) => any
@@ -147,6 +149,12 @@ class BulkOperationConfirmation extends React.Component<IBulkOperationProps, any
     this.props.onUpdateSucceeded("")
     this.props.onUpdateIgnored("")
     this.props.onUpdateFailed("")
+    // set bulkOperationCompleted to false
+    this.updateBulkOperationCompleted(false)
+  }
+
+  private updateBulkOperationCompleted = (bulkOperationCompleted) => {
+    this.props.updateBulkOperationCompleted(bulkOperationCompleted)
   }
 }
 

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -199,6 +199,8 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                         onUpdateSucceeded={this.updateUpdateSucceeded}
                         onUpdateIgnored={this.updateUpdateIgnored}
                         onUpdateFailed={this.updateUpdateFailed}
+                        bulkOperationCompleted={this.props.bulkOperationCompleted}
+                        updateBulkOperationCompleted={this.props.updateBulkOperationCompleted}
                     />}
 
                 {this.props.isEditMetadata && metadataModal}
@@ -389,7 +391,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                     }, () => {
                                         this.setState({ showBulkEditConfirmation: true })
                                         this.props.updateIsEditMetadata(false)
-                                        this.props.updateBulkOperationCompleted(true)
                                         this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
                                     })
                                 } else {
@@ -421,6 +422,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                     })
                 }
             })
+            this.props.updateBulkOperationCompleted(true)
         }
     }
 


### PR DESCRIPTION
This PR changes how icons are repopulated after bulk editing. Like bulk publish/unpublish, after closing of the confirmation dialog, icons will be repopulated.