### PR TITLE
CCS-4347-handle-multiple-repo-selections

### DIFF
--- a/pantheon-bundle/frontend/src/app/Pagination.test.tsx
+++ b/pantheon-bundle/frontend/src/app/Pagination.test.tsx
@@ -20,6 +20,7 @@ describe("Tests for Pagination", () => {
     showDropdownOptions={true}
     bottom={true}
     className={"test"}
+    currentBulkOperation={""}
 />)
     expect(view).toMatchSnapshot()
   })
@@ -37,6 +38,7 @@ describe("Tests for Pagination", () => {
       showDropdownOptions={true}
       bottom={true}
       className={"test"}
+      currentBulkOperation={""}
     />)
     const pageNumberDisplay = wrapper.find(LevelItem)
     expect(pageNumberDisplay.exists()).toBe(true)

--- a/pantheon-bundle/frontend/src/app/Pagination.tsx
+++ b/pantheon-bundle/frontend/src/app/Pagination.tsx
@@ -15,6 +15,7 @@ export interface IProps {
   showDropdownOptions: boolean
   bottom: boolean
   className?: string
+  currentBulkOperation: string
 }
 
 class Pagination extends React.Component<IProps> {
@@ -59,6 +60,11 @@ class Pagination extends React.Component<IProps> {
       this.nextPageButton = false;
     }
     if (this.props.pageNumber === 1 && this.props.nextPageRecordCount === 0) {
+      this.firstPageButton = true;
+      this.previousPageButton = true;
+      this.nextPageButton = true;
+    }
+    if(this.props.currentBulkOperation !== ""){
       this.firstPageButton = true;
       this.previousPageButton = true;
       this.nextPageButton = true;

--- a/pantheon-bundle/frontend/src/app/__snapshots__/searchResults.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/searchResults.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`SearchResults tests should render default Search component 1`] = `
   <Pagination
     bottom={true}
     className="results__pagination"
+    currentBulkOperation=""
     handleItemsPerPage={[Function]}
     handleMoveLeft={[Function]}
     handleMoveRight={[Function]}

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -169,6 +169,8 @@ class SearchResults extends Component<IProps, ISearchState> {
           showDropdownOptions={this.state.showDropdownOptions}
           bottom={this.state.bottom}
           className="results__pagination"
+          currentBulkOperation={this.props.currentBulkOperation}
+          
         />}
 
         {this.state.isEmptyResults && <EmptyState variant={EmptyStateVariant.small} className="search-results--empty">


### PR DESCRIPTION
when user selects title in search results component and then navigates to the next page, their previous selection/s are cleared.
This PR fixes the issue for now of disabling the pagination once a title is selected.