### PR TITLE
CCS-4359_bugfixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/BulkOperationPublish.test.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkOperationPublish.test.tsx
@@ -13,6 +13,8 @@ const props = {
     isBulkPublish: true,
     isBulkUnpublish: false,
     bulkOperationCompleted: true,
+    updateIsBulkPublish: (isBulkPublish) => anymatch,
+    updateIsBulkUnpublish: (isBulkUnpublish) => anymatch,
     updateBulkOperationCompleted: (bulkOperationCompleted) => anymatch
 }
 

--- a/pantheon-bundle/frontend/src/app/BulkOperationPublish.tsx
+++ b/pantheon-bundle/frontend/src/app/BulkOperationPublish.tsx
@@ -11,6 +11,8 @@ export interface IBulkOperationPublishProps {
     isBulkPublish: boolean
     isBulkUnpublish: boolean
     bulkOperationCompleted: boolean
+    updateIsBulkPublish: (isBulkPublish) => any
+    updateIsBulkUnpublish: (isBulkUnpublish) => any
     updateBulkOperationCompleted: (bulkOperationConfirmation) => any
 }
 
@@ -41,13 +43,20 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
         };
     }
 
+    public componentWillUnmount() {
+        // fix Warning: Can't perform a React state update on an unmounted component
+        this.setState = (state, callback) => {
+            return;
+        };
+    }
+
     public render() {
         const { isModalOpen } = this.state;
         const publishHeader = (
             <React.Fragment>
                 <Title headingLevel="h1" size={BaseSizes["2xl"]}>
                     {this.props.isBulkPublish ? 'Publish' : 'Unpublish'}
-            </Title>
+                </Title>
             </React.Fragment>
         )
         const publishModal = (
@@ -55,7 +64,7 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                 <Modal
                     variant={ModalVariant.medium}
                     title="Publish"
-                    isOpen={this.state.isModalOpen}
+                    isOpen={isModalOpen}
                     header={publishHeader}
                     aria-label="Publish"
                     onClose={this.handleModalClose}
@@ -88,7 +97,7 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                 <Modal
                     variant={ModalVariant.medium}
                     title="Unpublish"
-                    isOpen={this.state.isModalOpen}
+                    isOpen={isModalOpen}
                     header={publishHeader}
                     aria-label="Unpublish"
                     onClose={this.handleModalClose}
@@ -140,15 +149,16 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
 
     private handleModalClose = () => {
         this.setState({ isModalOpen: false }, () => {
+            this.setState({ showBulkConfirmation: false })
             this.props.updateBulkOperationCompleted(false)
+            this.props.updateIsBulkPublish(false)
+            this.props.updateIsBulkUnpublish(false)
         })
     }
 
     private onBulkPublish = (event) => {
         const formData = new FormData();
-
-        {this.props.isBulkPublish ? formData.append(":operation", "pant:publish") : formData.append(":operation", "pant:unpublish")}
-
+        { this.props.isBulkPublish ? formData.append(":operation", "pant:publish") : formData.append(":operation", "pant:unpublish") }
 
         const hdrs = {
             "Accept": "application/json",
@@ -156,14 +166,14 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
             "Access-Control-Allow-Origin": "*",
         }
         let variant
-        if(this.props.documentsSelected){
+        if (this.props.documentsSelected) {
             variant = this.props.documentsSelected[0].cells[1].title.props.href.split("?variant=")[1]
             formData.append("variant", variant)
         }
-        
+
         formData.append("locale", "en_US")
 
-        // reinitialize states
+        // reinitialize states for republishing
         if (this.props.documentsSelected.length > 0) {
             this.setState({
                 documentsSucceeded: [],
@@ -172,6 +182,14 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                 confirmationSucceeded: "",
                 confirmationIgnored: "",
                 confirmationFailed: "",
+                bulkUpdateFailure: 0,
+                bulkUpdateSuccess: 0,
+                bulkUpdateWarning: 0,
+                progressFailureValue: 0,
+                progressSuccessValue: 0,
+                progressWarningValue: 0,
+                showBulkConfirmation: false,
+                docsSelected: this.props.documentsSelected
             });
         }
 
@@ -183,42 +201,39 @@ class BulkOperationPublish extends React.Component<IBulkOperationPublishProps, a
                 let hrefPart = href.slice(0, href.indexOf("?"))
                 let modulePath = hrefPart.slice(hrefPart.indexOf("/repositories"))
                 const backend = "/content" + modulePath + `/en_US/variants/${variant}/draft`
+                let exist = this.props.isBulkPublish ? Utils.draftExist(backend) : false
 
-                Utils.draftExist(backend).then((exist) => {
-                    if (exist || this.props.isBulkUnpublish) {
-                        fetch("/content" + modulePath, {
-                            body: formData,
-                            method: "post",
-                            headers: hdrs
-                        }).then(response => {
-                            if (response.status === 201 || response.status === 200) {
-                                console.log(this.props.isBulkPublish ? "publish works: " + response.status : "unpublish works: " + response.status)
-                                this.setState({
-                                    documentsSucceeded: [...this.state.documentsSucceeded, modulePath],
-                                    bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
-                                }, () => {
-                                    this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
-                                }
-                                )
-                            } else {
-                                console.log(this.props.isBulkPublish ? "publish failed " + response.status : "unpublish failed " + response.status)
-                                this.setState({ bulkUpdateFailure: this.state.bulkUpdateFailure + 1, documentsFailed: [...this.state.documentsFailed, modulePath] }, () => {
-                                    this.calculateFailureProgress(this.state.bulkUpdateFailure)
-                                })
+                if (exist || this.props.isBulkUnpublish) {
+                    fetch("/content" + modulePath, {
+                        body: formData,
+                        method: "post",
+                        headers: hdrs
+                    }).then(response => {
+                        if (response.status === 201 || response.status === 200) {
+                            this.setState({
+                                documentsSucceeded: [...this.state.documentsSucceeded, modulePath],
+                                bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
+                            }, () => {
+                                this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
                             }
-                        })
-                    } else {
-                        console.log('no draft exists')
-                        this.setState({ bulkUpdateWarning: this.state.bulkUpdateWarning + 1, documentsIgnored: [...this.state.documentsIgnored, modulePath] }, () => {
-                            this.calculateWarningProgress(this.state.bulkUpdateWarning)
-                        })
-                    }
-                })
+                            )
+                        } else {
+                            this.setState({ bulkUpdateFailure: this.state.bulkUpdateFailure + 1, documentsFailed: [...this.state.documentsFailed, modulePath] }, () => {
+                                this.calculateFailureProgress(this.state.bulkUpdateFailure)
+                            })
+                        }
+                    })
+                } else {
+                    this.setState({ bulkUpdateWarning: this.state.bulkUpdateWarning + 1, documentsIgnored: [...this.state.documentsIgnored, modulePath] }, () => {
+                        this.calculateWarningProgress(this.state.bulkUpdateWarning)
+                    })
+                }
             }
 
         })
-        this.setState({ isModalOpen: false, showBulkConfirmation: true }, ()=>{
+        this.setState({ showBulkConfirmation: true }, () => {
             this.props.updateBulkOperationCompleted(true)
+            this.props.isBulkPublish ? this.props.updateIsBulkPublish(false) : this.props.updateIsBulkUnpublish(false)
         })
     }
 

--- a/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
+++ b/pantheon-bundle/frontend/src/app/bulkOperationMetadata.tsx
@@ -47,6 +47,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
             bulkUpdateSuccess: 0,
             bulkUpdateWarning: 0,
 
+            docsSelected: this.props.documentsSelected,
             documentsSucceeded: [""],
             documentsFailed: [""],
             documentsIgnored: [""],
@@ -77,7 +78,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                 <Modal
                     variant={ModalVariant.medium}
                     title="Edit metadata"
-                    isOpen={this.state.isModalOpen}
+                    isOpen={isModalOpen}
                     header={header}
                     aria-label="Edit metadata"
                     onClose={this.handleModalClose}
@@ -351,7 +352,8 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                     bulkUpdateFailure: 0,
                     progressSuccessValue: 0,
                     progressFailedValue: 0,
-                    progressWarningValue: 0
+                    progressWarningValue: 0,
+                    docsSelected: this.props.documentsSelected,
                 });
             }
             this.props.documentsSelected.map((r) => {
@@ -389,7 +391,6 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
                                         bulkUpdateSuccess: this.state.bulkUpdateSuccess + 1,
                                         showBulkEditConfirmation: true
                                     }, () => {
-                                        this.setState({ showBulkEditConfirmation: true })
                                         this.props.updateIsEditMetadata(false)
                                         this.calculateSuccessProgress(this.state.bulkUpdateSuccess)
                                     })
@@ -461,7 +462,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
 
     private calculateFailureProgress = (num: number) => {
         if (num >= 0) {
-            let stat = (num) / this.props.documentsSelected.length * 100
+            let stat = (num) / this.state.docsSelected.length * 100
             this.setState({ progressFailureValue: stat, showBulkConfirmation: true }, () => {
                 this.getDocumentFailed()
             })
@@ -470,7 +471,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
 
     private calculateSuccessProgress = (num: number) => {
         if (num >= 0) {
-            let stat = (num) / this.props.documentsSelected.length * 100
+            let stat = (num) / this.state.docsSelected.length * 100
             this.setState({ progressSuccessValue: stat, showBulkConfirmation: true }, () => {
                 this.getDocumentsSucceeded()
             })
@@ -479,7 +480,7 @@ class BulkOperationMetadata extends React.Component<IBulkOperationMetadataProps,
 
     private calculateWarningProgress = (num: number) => {
         if (num >= 0) {
-            let stat = (num) / this.props.documentsSelected.length * 100
+            let stat = (num) / this.state.docsSelected.length * 100
             this.setState({ progressWarningValue: stat, showBulkConfirmation: true }, () => {
                 this.getDocumentIgnored()
             })

--- a/pantheon-bundle/frontend/src/app/search.tsx
+++ b/pantheon-bundle/frontend/src/app/search.tsx
@@ -338,20 +338,24 @@ class Search extends Component<IAppState, ISearchState> {
                 updateIsEditMetadata={this.updateIsEditMetadata}
                 updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
-              {this.state.isBulkPublish && <BulkOperationPublish
+              {(this.state.isBulkPublish || this.state.bulkOperationCompleted) && <BulkOperationPublish
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isBulkPublish={this.state.isBulkPublish}
                 isBulkUnpublish={this.state.isBulkUnpublish}
                 bulkOperationCompleted={this.state.bulkOperationCompleted}
+                updateIsBulkPublish={this.updateIsBulkPublish}
+                updateIsBulkUnpublish={this.updateIsBulkUnpublish}
                 updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
-              {this.state.isBulkUnpublish && <BulkOperationPublish
+              {(this.state.isBulkUnpublish || this.state.bulkOperationCompleted) && <BulkOperationPublish
                 documentsSelected={this.state.documentsSelected}
                 contentTypeSelected={this.state.contentTypeSelected}
                 isBulkPublish={this.state.isBulkPublish}
                 isBulkUnpublish={this.state.isBulkUnpublish}
                 bulkOperationCompleted={this.state.bulkOperationCompleted}
+                updateIsBulkPublish={this.updateIsBulkPublish}
+                updateIsBulkUnpublish={this.updateIsBulkUnpublish}
                 updateBulkOperationCompleted={this.updateBulkOperationCompleted}
               />}
               {drawerContent}
@@ -669,7 +673,7 @@ class Search extends Component<IAppState, ISearchState> {
       }, () => {
 
         //determine if publish or unpublish bulk operation
-        if (text == 'publish') {
+        if (text === 'publish') {
           this.setState({ isBulkPublish: !this.state.isBulkPublish, isBulkUnpublish: false }, () => {
             if (this.state.bulkOperationWarn === false && this.state.repositoriesSelected.length === 1) {
               this.setState({ isBulkOperationButtonDisabled: false, bulkOperationCompleted: false })
@@ -678,7 +682,7 @@ class Search extends Component<IAppState, ISearchState> {
             }
           })
         }
-        else if (text == 'unpublish') {
+        else if (text === 'unpublish') {
           this.setState({ isBulkUnpublish: !this.state.isBulkUnpublish, isBulkPublish: false }, () => {
             if (this.state.bulkOperationWarn === false && this.state.repositoriesSelected.length === 1) {
               this.setState({ isBulkOperationButtonDisabled: false, bulkOperationCompleted: false })
@@ -694,8 +698,16 @@ class Search extends Component<IAppState, ISearchState> {
 
   }
 
-  private updateIsEditMetadata = (updateIsEditMetadata) => {
-    this.setState({ isEditMetadata: updateIsEditMetadata })
+  private updateIsEditMetadata = (isEditMetadata) => {
+    this.setState({ isEditMetadata })
+  }
+
+  private updateIsBulkPublish = (isBulkPublish) => {
+    this.setState({ isBulkPublish })
+  }
+
+  private updateIsBulkUnpublish = (isBulkUnpublish) => {
+    this.setState({ isBulkUnpublish })
   }
 
   private updateBulkOperationCompleted = (bulkOperationCompleted) => {
@@ -704,6 +716,7 @@ class Search extends Component<IAppState, ISearchState> {
       this.setState({
         isBulkPublish: false,
         isBulkUnpublish: false,
+        documentsSelected: [],
       })
     }
     this.setState({ bulkOperationCompleted }, () => {

--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -124,7 +124,9 @@ class SearchResults extends Component<IProps, ISearchState> {
       || this.props.keyWord !== prevProps.keyWord
       || this.props.filters !== prevProps.filters
       || this.props.onGetdocumentsSelected !== prevProps.onGetdocumentsSelected
-      || this.props.bulkOperationCompleted !== prevProps.bulkOperationCompleted
+      || (this.props.bulkOperationCompleted !== prevProps.bulkOperationCompleted
+        && this.props.currentBulkOperation.length === 0
+      )
     ) {
       this.doSearch()
     }


### PR DESCRIPTION
This PR addresses the following bulk republish issues:
* when user does bulk publish/unpublish over and over, the button click on Publish/Unpublish unselects the checkboxes
* when user does bulk unpublish over and over, the unpublish action does not happen
