### PR TITLE
CCS-4347: update to disabling pagination for search results

### DIFF
--- a/pantheon-bundle/frontend/src/app/searchResults.tsx
+++ b/pantheon-bundle/frontend/src/app/searchResults.tsx
@@ -347,6 +347,7 @@ class SearchResults extends Component<IProps, ISearchState> {
     this.setState({ pageLimit: pageLimitValue, page: 1, itemsPerPage: pageLimitValue }, () => {
       this.props.onGetdocumentsSelected([])
       this.doSearch()
+      this.props.onSelectContentType("")
     })
   }
 


### PR DESCRIPTION
fix so when a user selects number of results to display from pagination, the pagination is no longer disabled and user could move between pages