### PR TITLE
CCS-4183-bugfixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/__snapshots__/contentDisplay.test.tsx.snap
+++ b/pantheon-bundle/frontend/src/app/__snapshots__/contentDisplay.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`ContentDisplay tests for Assembly should render ContentDisplay componen
     <Versions
       assemblies={Array []}
       attributesFilePath=""
+      canRegeneratePortalUrl={[Function]}
       contentType="module"
       modulePath=""
       onGetProduct={[Function]}
@@ -289,6 +290,7 @@ exports[`ContentDisplay tests for Module should render ModuleDisplay component 1
     <Versions
       assemblies={Array []}
       attributesFilePath=""
+      canRegeneratePortalUrl={[Function]}
       contentType="module"
       modulePath=""
       onGetProduct={[Function]}

--- a/pantheon-bundle/frontend/src/app/contentDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/contentDisplay.tsx
@@ -30,6 +30,7 @@ export interface IContentDisplayState {
     assemblyData: any
     firstPublishDate: string
     lastPublishDate: string
+    regeneratePortalUrl: boolean
 }
 
 export interface IModuleDisplayState extends IContentDisplayState {
@@ -68,7 +69,8 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
             versionUrlFragment: "",
             locale: "",
             firstPublishDate: "",
-            lastPublishDate: ""
+            lastPublishDate: "",
+            regeneratePortalUrl: false
         }
     }
 
@@ -81,6 +83,15 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
         this.getPortalHostUrl()
         this.getLocale(this.props.location.pathname)
 
+    }
+
+    public componentDidUpdate(prevProps, prevState) {
+        if (prevState.regeneratePortalUrl !== this.state.regeneratePortalUrl) {
+            this.getPortalUrl(this.state.modulePath, this.state.variant)
+            if(this.state.regeneratePortalUrl === true){
+                this.setState({regeneratePortalUrl: false})
+            }
+        }
     }
 
     public render() {
@@ -222,6 +233,7 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                         onGetUrl={this.onGetUrl}
                         onGetProduct={this.getProduct}
                         onGetVersion={this.getVersion}
+                        canRegeneratePortalUrl={this.canRegeneratePortalUrl}
                     />
                 </Card>
 
@@ -509,6 +521,10 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                     })
                 }
             })
+    }
+
+    private canRegeneratePortalUrl = (regeneratePortalUrl: boolean) => {
+        this.setState({regeneratePortalUrl})
     }
 
 }

--- a/pantheon-bundle/frontend/src/app/versions.test.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.test.tsx
@@ -26,6 +26,7 @@ const props = {
     variant: "test",
     variantUUID: "abcd-1234",
     versionModulePath: "/modules/test_module/en_US/variants/test/draft",
+    canRegeneratePortalUrl: (regeneratePortalUrl) => anymatch
 }
 
 describe("Versions tests", () => {
@@ -199,6 +200,7 @@ describe("Versions tests", () => {
             variant: "DEFAULT",
             variantUUID: "abcd-1234",
             versionModulePath: "versionPath",
+            canRegeneratePortalUrl:(regeneratePortalUrl) => anymatch
         }
         state.updateDate(1, "1234")
         expect(state.modulePath).toEqual("somePath")

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -34,6 +34,7 @@ export interface IProps {
     updateDate: (releaseVersion, variantUUID) => any
     onGetProduct: (productValue) => any
     onGetVersion: (versionValue) => any
+    canRegeneratePortalUrl: (regeneratePortalUrl) => any
 }
 
 // Define properties in Metadata
@@ -562,7 +563,7 @@ class Versions extends Component<IProps, IState> {
                             canChangePublishState: true,
                             publishAlertVisible: false,
                             showMetadataAlertIcon: false
-                        })
+                        }, () => this.props.canRegeneratePortalUrl(true))
                     } else {
                         console.log(buttonText + " failed " + response.status)
                         this.setState({ publishAlertVisible: true })
@@ -638,7 +639,7 @@ class Versions extends Component<IProps, IState> {
                         canChangePublishState: true,
                         publishAlertVisible: false,
                         successAlertVisible: true,
-                    })
+                    }, () => this.props.canRegeneratePortalUrl(true))
                     if (this.state.metadataPath.endsWith("/draft")) {
                         this.setState({ showMetadataAlertIcon: false })
                         this.fetchVersions()


### PR DESCRIPTION
This PR addresses the following UI issues on Pre-live url:
* After publish/unpublish, it requires a page refresh to see Customer Portal Url/Pre-live  Url
* After modifying product version on a draft document, it requires a page fresh to see Pre-live url updated with the  new product verison fragment