### PR TITLE
 feat: use first para as abstract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sling-org-apache-sling-karaf-configs/.settings
 
 pantheon-karaf-dist/src/main/resources/etc/keystore/
 pantheon-karaf-dist/src/main/resources/etc/org.ops4j.pax.web.cfg
+.m2

--- a/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
+++ b/pantheon-bundle/src/main/java/com/redhat/pantheon/asciidoctor/extension/MetadataExtractorTreeProcessor.java
@@ -122,10 +122,23 @@ public class MetadataExtractorTreeProcessor extends Treeprocessor {
                             }
                         })
                         .findFirst();
+
+         // if no abstract was specified in the source, use the first paragraph
+         // as long as the file has more than one block
+         if (!abstractNode.isPresent() && allNodes.size() > 1) {
+            abstractNode = allNodes.stream().filter(block -> {
+                try {
+                    return block.getContext().equals("paragraph");
+                } catch (Exception e) {
+                    return false;
+                }
+            }).findFirst();
+        }
+
         abstractNode.ifPresent(node -> documentMetadata.mAbstract().set(node.getContent().toString()));
 
         // if no abstract is detected, reset if
-        if(!abstractNode.isPresent()) {
+        if (!abstractNode.isPresent()) {
             documentMetadata.mAbstract().set(null);
         }
     }

--- a/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ModuleMetadataExtractorTreeProcessorTest.java
+++ b/pantheon-bundle/src/test/java/com/redhat/pantheon/asciidoctor/extension/ModuleMetadataExtractorTreeProcessorTest.java
@@ -73,6 +73,37 @@ class ModuleMetadataExtractorTreeProcessorTest {
     }
 
     @Test
+    void extractMetadataAbstractInferred() {
+        // Given
+        slingContext.build().resource("/content/module1/locales/en_US/1/metadata").commit();
+        ModuleMetadata metadata =
+                SlingModels.getModel(
+                        slingContext.resourceResolver().getResource(
+				"/content/module1/locales/en_US/1/metadata"),
+			ModuleMetadata.class);
+        Resource module = slingContext.resourceResolver().getResource("/content/module1");
+        MetadataExtractorTreeProcessor extension = new MetadataExtractorTreeProcessor(metadata);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.javaExtensionRegistry().treeprocessor(extension);
+        final String adocContent = "// Some comment.\n" 
+                                 + "\n" 
+                                 + "[id='something_{context}']\n"
+                                 + "= A title for content\n" 
+                                 + "\n"
+                                 + "This para is selected as the abstract even if the role is not set.\n" 
+                                 + "\n"
+                                 + "Some other text or block like a procedure.";
+
+        // When
+        asciidoctor.load(adocContent, new HashMap<>());
+
+        // Then
+        assertEquals("A title for content", metadata.title().get());
+        assertEquals("This para is selected as the abstract even if the role is not set.",
+			metadata.mAbstract().get());
+    }
+
+    @Test
     void extractHeadline() {
         // Given
         slingContext.build()


### PR DESCRIPTION
Because writers update most ADOC files and specify
the first para as the abstract, just use the first
para as the abstract if it is not explicitly specified.