### PR TITLE
dateFirstPublsihed_UI_fixes

### DIFF
--- a/pantheon-bundle/frontend/src/app/contentDisplay.tsx
+++ b/pantheon-bundle/frontend/src/app/contentDisplay.tsx
@@ -195,7 +195,7 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                                 <strong><span id="span-source-type-lastpublished">Last Published Date</span></strong>
                                 <br />
                                 <span>
-                                    {this.state.lastPublishDate != undefined && this.state.lastPublishDate.trim() !== ""
+                                    {this.state.lastPublishDate !== undefined && this.state.lastPublishDate.trim() !== ""
                                         && this.state.lastPublishDate.length >= 15 ?
                                         new Intl.DateTimeFormat("en-GB", { year: "numeric", month: "long", day: "numeric" }).format(new Date(this.state.lastPublishDate)) : "--"}
                                 </span>
@@ -285,8 +285,12 @@ class ContentDisplay extends Component<any, IModuleDisplayState | IAssemblyDispl
                             for (const offspring of myGrandchild.__children__) {
                                 if (offspring.__name__ === "metadata") {
                                     if (myGrandchild.__name__ === "released") {
+                                        if (offspring["pant:dateFirstPublished"] !== undefined) {
+                                            this.setState({
+                                                firstPublishDate: offspring["pant:dateFirstPublished"],
+                                            })
+                                        }
                                         this.setState({
-                                            firstPublishDate: offspring["pant:dateFirstPublished"],
                                             lastPublishDate: offspring["pant:datePublished"]
                                         })
                                     }

--- a/pantheon-bundle/frontend/src/app/versions.tsx
+++ b/pantheon-bundle/frontend/src/app/versions.tsx
@@ -878,6 +878,9 @@ class Versions extends Component<IProps, IState> {
                 }
 
             })
+            .catch((error) => {
+                // console.log("No validations node for " + validationPath + " => ", error)
+            })
     }
 
     private onClickTree = (evt, treeViewItem, parentItem) => {


### PR DESCRIPTION
pant:dateFirestPublished was introduced a couple of months ago while we have documents published without that attribute. This PR fixes the display error when dateFirstPublished is missing on released metadata node.