### PR TITLE
CCS-4579: Allow xref-ids to wrap so they can be copied

### DIFF
--- a/pantheon-bundle/frontend/src/app/app.css
+++ b/pantheon-bundle/frontend/src/app/app.css
@@ -143,3 +143,10 @@ color: var(--pf-global--success-color--100)
     -ms-user-select: text;
     user-select: text;
 }
+
+.pf-c-tree-view__node {
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}

--- a/pantheon-bundle/frontend/src/app/app.css
+++ b/pantheon-bundle/frontend/src/app/app.css
@@ -132,4 +132,14 @@ color: var(--pf-global--success-color--100)
 .repo-list-container{
     height: 500px;
     overflow-y: auto;
-}  
+}
+
+.pf-c-tree-view__node-text[class] {
+    overflow:visible;
+    white-space:break-spaces;
+    overflow-wrap: break-word;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/CCS-4579

Allow xref id's to wrap so they can be copied. I'm not sure how to get this UI for testing, but once it is you should be able to see the entire xref and it should be selectable/copyable.

Should look like this:
![image](https://user-images.githubusercontent.com/5607236/128908050-778ea224-bab6-4c7a-98b0-ab5ac6c59aca.png)
