### PR TITLE
clean up github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,17 +38,6 @@ jobs:
     - name: Build with Maven
       run: ./mvnw clean install -pl sling-org-apache-sling-karaf-features,sling-org-apache-sling-karaf-configs,pantheon-bundle,pantheon-karaf-feature,pantheon-karaf-dist
 
-    - name: Install Go dependencies
-      working-directory: tools/git2pantheon
-      run: |
-        go get gopkg.in/src-d/go-git.v4
-
-    - name: Build git2pantheon
-      working-directory: tools/git2pantheon
-      run: |
-        go build
-        go test -race -coverprofile=coverage.txt -covermode=atomic
-
     - name: Push to Codecov
       uses: codecov/codecov-action@v1
       if: ${{ matrix.java }} == '1.8'


### PR DESCRIPTION
This PR removes the golang related github actions. We depreciated the golang tool a few months ago. And the golang tests returns errors during the build:

2021-08-16T09:01:36.7169944Z 09:01:36.716864 main.go:74: Invalid request method GET
2021-08-16T09:01:36.7170895Z {"error" : "Invalid request method"}
2021-08-16T09:01:36.7171408Z 
2021-08-16T09:01:36.7172231Z 09:01:36.716960 main.go:38: Error in unmarshalling request body unexpected end of JSON input
2021-08-16T09:01:36.7173345Z {"error" : "Error reading request body due to unexpected end of JSON input "}
2021-08-16T09:01:36.7174089Z 
2021-08-16T09:01:36.7174666Z 09:01:36.717109 main.go:45: repo:  test
2021-08-16T09:01:36.7175373Z 09:01:36.717124 main.go:46: branch: 
2021-08-16T09:01:36.7176149Z {"error" : "The repository entered does not look like a git repo"}
2021-08-16T09:01:36.7176782Z 
2021-08-16T09:01:36.7177297Z COMMIT_HASH is : not set
2021-08-16T09:01:36.7178045Z {"error" : "Invalid request method"}