### PR TITLE
 CCS-5741: Reverting previous template change

### DIFF
--- a/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
+++ b/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/document.html.haml
@@ -13,7 +13,7 @@
 - pantheonCssPath = "//#{portalUrl}/webassets/avalon/j/public_modules/node_modules/@cpelements/cp-documentation/dist/rhdocs.min.css"
 
 
-- wrappingTag = 'div'
+- wrappingTag = 'cp-documentation'
 
 %html{:lang=>(attr :lang, 'en')}
   %head


### PR DESCRIPTION
It might cause issues with how Pantheon processes data, and there might be another way to fix the issue of double shadow roots on Drupal.